### PR TITLE
Fix long course names

### DIFF
--- a/components/d2l-enrollment-card/d2l-enrollment-card.html
+++ b/components/d2l-enrollment-card/d2l-enrollment-card.html
@@ -30,6 +30,11 @@ Polymer-based web component for a course/enrollment card.
 				position: relative;
 			}
 
+			d2l-card {
+				/* Prevents long, non-breaking course names from overflowing */
+				width: 100%;
+			}
+
 			d2l-card:hover,
 			d2l-card:focus {
 				cursor: pointer;


### PR DESCRIPTION
This was set in `d2l-course-image-tile` on the `d2l-image-tile`, but I forgot to move it over. Only affects long, non-breaking course names.