### PR TITLE
Majones/fire event when enrollment fetched

### DIFF
--- a/components/d2l-enrollment-card/d2l-enrollment-card.html
+++ b/components/d2l-enrollment-card/d2l-enrollment-card.html
@@ -641,8 +641,8 @@ Polymer-based web component for a course/enrollment card.
 				this._organizationUrl = enrollment.getLinkByRel(this.HypermediaRels.organization).href;
 
 				this.fire('d2l-enrollment-card-fetched', {
-					href: this._organizationUrl,
-					enrollment: this._getEntityIdentifier(this._enrollment)
+					organizationUrl: this._organizationUrl,
+					enrollmentUrl: this._getEntityIdentifier(this._enrollment)
 				});
 
 				return this._fetchSirenEntity(this._organizationUrl)

--- a/components/d2l-enrollment-card/d2l-enrollment-card.html
+++ b/components/d2l-enrollment-card/d2l-enrollment-card.html
@@ -640,6 +640,11 @@ Polymer-based web component for a course/enrollment card.
 
 				this._organizationUrl = enrollment.getLinkByRel(this.HypermediaRels.organization).href;
 
+				this.fire('d2l-enrollment-card-fetched', {
+					href: this._organizationUrl,
+					enrollment: this._getEntityIdentifier(this._enrollment)
+				});
+
 				return this._fetchSirenEntity(this._organizationUrl)
 					.then(this._handleOrganizationResponse.bind(this));
 			},


### PR DESCRIPTION
Fires the event to help keep the structure containing the card keep a unique index based on organization.