### PR TITLE
US97555 Remove image overlay

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "d2l-menu": "^1.0.4",
     "d2l-offscreen": "^3.0.3",
     "d2l-organization-hm-behavior": "Brightspace/organization-hm-behavior#^2.0.1",
-    "d2l-organizations": "BrightspaceHypermediaComponents/organizations#0.0.2-hybrid",
+    "d2l-organizations": "BrightspaceHypermediaComponents/organizations#0.0.3-hybrid",
     "d2l-tile": "^3.1.2",
     "iron-a11y-announcer": "^2.0.0",
     "polymer": "1 - 2",

--- a/components/d2l-enrollment-card/d2l-enrollment-card.html
+++ b/components/d2l-enrollment-card/d2l-enrollment-card.html
@@ -45,22 +45,12 @@ Polymer-based web component for a course/enrollment card.
 				cursor: pointer;
 				border: 1px solid var(--d2l-color-celestine);
 			}
+			d2l-card[disabled] {
+				filter: grayscale(1);
+			}
 			d2l-card[disabled]:hover,
 			d2l-card[disabled]:focus {
 				cursor: not-allowed;
-			}
-
-			d2l-card:hover .image-container,
-			d2l-card:focus .image-container {
-				-webkit-filter: saturate(1.15) contrast(1.15);
-				filter: saturate(1.15) contrast(1.15);
-				transform: scale(1.1);
-			}
-			d2l-card[disabled]:hover .image-container,
-			d2l-card[disabled]:focus .image-container {
-				-webkit-filter: none;
-				filter: none;
-				transform: none;
 			}
 
 			d2l-icon {
@@ -71,15 +61,6 @@ Polymer-based web component for a course/enrollment card.
 
 			.flex {
 				display: flex;
-			}
-
-			d2l-card:hover .course-text,
-			d2l-card:focus .course-text {
-				text-decoration: underline;
-			}
-			d2l-card[disabled]:hover .course-text,
-			d2l-card[disabled]:focus .course-text {
-				text-decoration: none;
 			}
 
 			.pin-indicator {
@@ -149,17 +130,9 @@ Polymer-based web component for a course/enrollment card.
 			.overlay[hidden] {
 				display: none;
 			}
-			.overlay-text {
-				font-size: 1rem;
-				font-weight: bold;
-			}
-			.overlay-date {
-				font-size: 0.7rem;
-			}
 
 			.image-container {
 				height: var(--course-image-height);
-				transition: filter 0.25s, -webkit-filter 0.25s, transform 0.5s ease-in-out;
 			}
 
 			.icon-container {
@@ -216,12 +189,12 @@ Polymer-based web component for a course/enrollment card.
 				border: 3px solid white;
 				background-color: #ffce51;
 				position: absolute;
-				top: calc(-1 * var(--course-image-height) - 12px);
-				right: -12px;
+				top: -6px;
+				right: -6px;
 			}
 			[dir="rtl"] .alert-colour-circle {
 				right: auto;
-				left: -2px;
+				left: -6px;
 			}
 		</style>
 
@@ -234,11 +207,6 @@ Polymer-based web component for a course/enrollment card.
 						type="tile">
 					</d2l-course-image>
 				</div>
-				<div hidden$="[[!_hasOverlay]]" class="overlay">
-					<div class="overlay-text">[[_overlayTitle]]</div>
-					<div class="overlay-date">[[_overlayDate]]</div>
-					<div>[[_overlayInactive]]</div>
-				</div>
 				<div hidden$="[[!_imageLoading]]" class="overlay">
 					<d2l-loading-spinner hidden$="[[!_imageLoadingProgress]]" size="85"></d2l-loading-spinner>
 					<div class="icon-container" hidden$="[[_imageLoadingProgress]]">
@@ -249,14 +217,11 @@ Polymer-based web component for a course/enrollment card.
 				<div class="alert-colour-circle" hidden$="[[!_startedInactive]]"></div>
 			</div>
 
-			<div class="flex" slot="content">
-				<d2l-organization-info
-					href="[[_organizationUrl]]"
-					presentation-href="[[presentationHref]]">
-				</d2l-organization-info>
-				<d2l-offscreen>[[_overlayAnnounceText]]</d2l-offscreen>
-			</div>
-
+			<d2l-organization-info
+				slot="content"
+				href="[[_organizationUrl]]"
+				presentation-href="[[presentationHref]]">
+			</d2l-organization-info>
 			<d2l-organization-updates
 				slot="footer"
 				href="[[_notificationsUrl]]"
@@ -365,10 +330,6 @@ Polymer-based web component for a course/enrollment card.
 					type: String,
 					computed: '_computeCourseSettingsLabel(_organization)'
 				},
-				_hasOverlay: {
-					type: Boolean,
-					value: false
-				},
 				_image: Object,
 				_imageLoading: {
 					type: Boolean,
@@ -382,13 +343,6 @@ Polymer-based web component for a course/enrollment card.
 				_organization: Object,
 				_organizationUrl: String,
 				_organizationHomepageUrl: String,
-				_overlayAnnounceText: {
-					type: String,
-					computed: '_computeOverlayAnnounceText(_organization)'
-				},
-				_overlayDate: String,
-				_overlayInactive: String,
-				_overlayTitle: String,
 				_pinButtonLabel: {
 					type: String,
 					computed: '_computePinButtonLabel(_organization)'
@@ -402,7 +356,8 @@ Polymer-based web component for a course/enrollment card.
 			],
 			observers: [
 				'_fetchEnrollment(_load, href)',
-				'_fetchPresentationData(_load, presentationHref)'
+				'_fetchPresentationData(_load, presentationHref)',
+				'_calculatePastCourseAttribute(_organization)'
 			],
 			ready: function() {
 				Polymer.IronA11yAnnouncer.requestAvailability();
@@ -488,44 +443,28 @@ Polymer-based web component for a course/enrollment card.
 					&& organization.properties
 					&& this.localize('courseSettings', 'course', organization.properties.name);
 			},
-			_computeOverlayAnnounceText: function(organization) {
+			_calculatePastCourseAttribute: function(organization) {
 				var nowDate = Date.now();
 				var endDate = Date.parse(organization.properties.endDate);
 				var startDate = Date.parse(organization.properties.startDate);
 				var inactive = !organization.properties.isActive;
 
 				this.removeAttribute('past-course');
-				this._hasOverlay = true;
-
 				if (endDate < nowDate) {
 					this.setAttribute('past-course', '');
-					endDate = new Date(endDate);
-					this._overlayDate = this.formatDateTime(endDate, {format: 'medium'});
-					this._overlayInactive = null;
-					this._overlayTitle = this.localize('overlay.courseClosed');
-					return this.localize('overlay.courseClosedOn', 'dateTime', this.formatDate(endDate, {format: 'MMMM d, yyyy'}) + ' ' + this.formatTime(endDate));
-				} else if (startDate > nowDate) {
-					startDate = new Date(startDate);
-					this._overlayDate = this.formatDateTime(startDate, {format: 'medium'});
-					this._overlayInactive = inactive ? this.localize('brackets', 'content', this.localize('overlay.inactive')) : null;
-					this._overlayTitle = this.localize('overlay.courseOpens');
-					return this.localize('overlay.courseOpeningOn', 'dateTime', this.formatDate(startDate, {format: 'MMMM d, yyyy'}) + ' ' + this.formatTime(startDate));
-				} else if (inactive) {
-					this._overlayDate = null;
-					this._overlayInactive = this.localize('overlay.inactive');
-					this._overlayTitle = null;
-					if (startDate && this._pinned && organization.hasLinkByRel(this.HypermediaRels.courseOfferingInfoPage)) {
-						// We only care about calling out started-inactive courses if they're pinned, and if the user is admin-ish
-						this._startedInactive = true;
-						this.fire('started-inactive');
-					}
-					return this._overlayInactive;
-				} else {
-					this._overlayDate = null;
-					this._overlayInactive = null;
-					this._overlayTitle = null;
-					this._hasOverlay = false;
-					return null;
+					return;
+				}
+
+				if (
+					inactive
+					&& startDate
+					&& startDate < nowDate
+					&& this._pinned
+					&& organization.hasLinkByRel(this.HypermediaRels.courseOfferingInfoPage)
+				) {
+					// We only care about calling out started-inactive courses if they're pinned, and if the user is admin-ish
+					this._startedInactive = true;
+					this.fire('started-inactive');
 				}
 			},
 			_computePinButtonLabel: function(organization) {

--- a/test/d2l-enrollment-card/d2l-enrollment-card.js
+++ b/test/d2l-enrollment-card/d2l-enrollment-card.js
@@ -270,15 +270,6 @@ describe('d2l-enrollment-card', () => {
 			expect(component._courseSettingsLabel).to.equal('Course name course settings');
 		});
 
-		it('should update _overlayAnnounceText', () => {
-			var spy = sandbox.spy(component, '_computeOverlayAnnounceText');
-
-			component._organization = organizationEntity;
-
-			expect(spy).to.have.been.called;
-			expect(component._overlayAnnounceText).to.match(/Opens on/);
-		});
-
 		it('should update _pinButtonLabel', () => {
 			var spy = sandbox.spy(component, '_computePinButtonLabel');
 
@@ -379,7 +370,7 @@ describe('d2l-enrollment-card', () => {
 				}
 			}));
 
-			var imageOverlay = component.$$('div.overlay:nth-of-type(3)');
+			var imageOverlay = component.$$('div.overlay');
 			expect(imageOverlay.hasAttribute('hidden')).to.be.false;
 			var spinner = component.$$('.overlay d2l-loading-spinner');
 			expect(spinner.hasAttribute('hidden')).to.be.false;
@@ -396,7 +387,7 @@ describe('d2l-enrollment-card', () => {
 			}));
 
 			clock.tick(1001);
-			var imageOverlay = component.$$('div.overlay:nth-of-type(3)');
+			var imageOverlay = component.$$('div.overlay');
 			expect(imageOverlay.hasAttribute('hidden')).to.be.false;
 			var spinner = component.$$('.overlay d2l-loading-spinner');
 			expect(spinner.hasAttribute('hidden')).to.be.true;
@@ -419,7 +410,7 @@ describe('d2l-enrollment-card', () => {
 			}));
 
 			clock.tick(1001);
-			var imageOverlay = component.$$('div.overlay:nth-of-type(3)');
+			var imageOverlay = component.$$('div.overlay');
 			expect(imageOverlay.hasAttribute('hidden')).to.be.false;
 			var spinner = component.$$('.overlay d2l-loading-spinner');
 			expect(spinner.hasAttribute('hidden')).to.be.true;
@@ -429,70 +420,6 @@ describe('d2l-enrollment-card', () => {
 			clock.tick(1001);
 			expect(imageOverlay.hasAttribute('hidden')).to.be.true;
 			clock.restore();
-		});
-
-	});
-
-	describe('Notification Overlay', () => {
-
-		var futureDate = new Date(3000, 0, 1, 15, 5).toISOString(),
-			pastDate = new Date(1900, 3, 30, 4, 38).toISOString(),
-			formattedFutureDateTime = 'Jan 1, 3000 3:05 PM',
-			formattedPastDateTime = 'Apr 30, 1900 4:38 AM';
-
-		[
-			{ start: futureDate, end: futureDate, active: false },
-			{ start: futureDate, end: futureDate, active: true },
-			{ start: pastDate, end: pastDate, active: false },
-			{ start: pastDate, end: pastDate, active: true },
-			{ start: pastDate, end: futureDate, active: false },
-			{ start: pastDate, end: futureDate, active: true },
-			{ start: null, end: futureDate, active: false },
-			{ start: null, end: futureDate, active: true }
-		].forEach(testCase => {
-
-			it(`${testCase.start}, ${testCase.end}, ${testCase.active}`, () => {
-				organizationEntity.properties.startDate = testCase.start;
-				organizationEntity.properties.endDate = testCase.end;
-				organizationEntity.properties.isActive = testCase.active;
-				component._organization = organizationEntity;
-
-				var overlay = component.$$('div.overlay:nth-of-type(2):not([hidden])');
-				if (
-					testCase.end === futureDate
-					&& (testCase.start === pastDate || !testCase.start)
-					&& testCase.active
-				) {
-					expect(overlay).to.be.null;
-					return;
-				}
-				expect(overlay).to.not.be.null;
-
-				var overlayTitleText = overlay.querySelector('.overlay-text').innerText;
-				var overlayDateText = overlay.querySelector('.overlay-date').innerText;
-				var overlayInactiveText = overlay.querySelector('.overlay-date + div').innerText;
-
-				if (testCase.start === futureDate) {
-					expect(overlayTitleText).to.equal('Opens On');
-					expect(overlayDateText).to.equal(formattedFutureDateTime);
-				} else if (testCase.end === pastDate) {
-					expect(overlayTitleText).to.equal('Closed');
-					expect(overlayDateText).to.equal(formattedPastDateTime);
-				} else {
-					expect(overlayTitleText).to.be.empty;
-					expect(overlayDateText).to.be.empty;
-				}
-
-				if (testCase.active || testCase.end === pastDate) {
-					expect(overlayInactiveText).to.be.empty;
-				} else if (testCase.start === futureDate) {
-					expect(overlayInactiveText).to.equal('(Inactive)');
-				} else {
-					expect(overlayInactiveText).to.equal('Inactive');
-				}
-
-			});
-
 		});
 
 	});


### PR DESCRIPTION
The `d2l-organization-info` component now supports showing additional information for future/past/inactive courses, so the image overlay is being retired. Unfortunately, there is still some remaining date-related code here, to allow us to set the `past-course` attribute on the card, as well as greying out inaccessible courses. There is probably a better way to do this, but the implementation of this behaviour in `d2l-organization-info` isn't quite complete yet anyway - we are still missing the status badge, which will slightly modify the available information.

Requires https://github.com/BrightspaceHypermediaComponents/organizations/pull/5, and a `bower.json` update once that has been released.