### PR TITLE
Bump d2l-tile

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
     "d2l-offscreen": "^3.0.3",
     "d2l-organization-hm-behavior": "Brightspace/organization-hm-behavior#^2.0.1",
     "d2l-organizations": "BrightspaceHypermediaComponents/organizations#0.0.3-hybrid",
-    "d2l-tile": "^3.1.2",
+    "d2l-tile": "^4.0.0",
     "iron-a11y-announcer": "^2.0.0",
     "polymer": "1 - 2",
     "siren-parser-import": "Brightspace/siren-parser-import#^7.0.0"


### PR DESCRIPTION
This includes the change to add a `name="content"` to the content slot of `d2l-card`, which we now use here in `d2l-enrollment-card`.