### PR TITLE
Relative dates check year when deciding to be shown.

### DIFF
--- a/components/d2l-user-activity-usage/d2l-user-activity-usage.html
+++ b/components/d2l-user-activity-usage/d2l-user-activity-usage.html
@@ -62,9 +62,9 @@ Polymer-based web component for a organization due and completion dates.
 				var dateTypeText = isCompletionDate ? 'completed' : 'due';
 
 				var dateText;
-				if (date.getDate() === nowDate.getDate()) {
+				if (date.getDate() === nowDate.getDate() && date.getYear() === nowDate.getYear()) {
 					dateText = this.localize(dateTypeText + 'Today');
-				} else if (date.getDate() === tomorrowDate.getDate()) {
+				} else if (date.getDate() === tomorrowDate.getDate() && date.getYear() === nowDate.getYear()) {
 					dateText = this.localize(dateTypeText + 'Tomorrow');
 				} else {
 					dateText = this.localize(dateTypeText + 'On', 'dateTime', this.formatDate(date, {format: this._dateFormat(date, nowDate)}));

--- a/test/d2l-user-activity-usage/d2l-user-activity-usage.js
+++ b/test/d2l-user-activity-usage/d2l-user-activity-usage.js
@@ -141,6 +141,10 @@ describe('d2l-user-activity-usage', () => {
 					date: new Date(24 * 3600 * 1000 * 7 + offset),
 					display: 'Due Jan 8'
 				},
+				{
+					date: new Date(24 * 3600 * 1000 * 365 + offset),
+					display: 'Due Jan 1, 1971'
+				},
 			].forEach((testCase) => {
 				it(testCase.display, (done) => {
 					var entities = [


### PR DESCRIPTION
When a due date is set to `tomorrow + 1 year` then it would show as `due tomorrow`. Now it shows the correct date.