### PR TITLE
 Temporary fix to keep title text aligned with[out] badge.

### DIFF
--- a/components/d2l-enrollment-card/d2l-enrollment-card.html
+++ b/components/d2l-enrollment-card/d2l-enrollment-card.html
@@ -155,6 +155,9 @@ Polymer-based web component for a course/enrollment card.
 				flex-direction: column;
 				margin: -0.35rem 0 -0.1rem -0.05rem;
 			}
+			.content-flex[badge] {
+				margin-top: -0.855rem;
+			}
 			.badge {
 				background-color: #FFFFFF;
 				box-shadow: 0 0 0 2px #FFFFFF;
@@ -166,6 +169,9 @@ Polymer-based web component for a course/enrollment card.
 				margin: -0.7rem 0 0 0.2rem;
 			}
 
+			d2l-organization-updates[badge] {
+				margin-top: -1.205rem;
+			}
 		</style>
 
 		<d2l-card
@@ -194,12 +200,13 @@ Polymer-based web component for a course/enrollment card.
 
 			<d2l-organization-updates
 				combined
+				badge$="[[_badgeText]]"
 				slot="content"
 				href="[[_notificationsUrl]]"
 				presentation-href="[[presentationHref]]">
 			</d2l-organization-updates>
 
-			<div class="content-flex" slot="content">
+			<div class="content-flex" slot="content" badge$="[[_badgeText]]">
 				<d2l-organization-info
 					href="[[_organizationUrl]]"
 					presentation-href="[[presentationHref]]">
@@ -669,7 +676,9 @@ Polymer-based web component for a course/enrollment card.
 				this._accessibilityDataReset();
 			},
 			_badgeTextChange: function(badgeText) {
-				if (!badgeText) return;
+				if (!badgeText) {
+					return;
+				}
 
 				this._accessibilityData.badge = badgeText;
 				this._accessibilityDataReset();


### PR DESCRIPTION
Note this one was built off of https://github.com/BrightspaceHypermediaComponents/enrollments/pull/15

![image](https://user-images.githubusercontent.com/13232226/44606532-63ce7d80-a7bb-11e8-9f8c-36b523dd3a56.png)
