### PR TITLE
Update to use normal card.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "d2l-course-image": "Brightspace/course-image#^2.1.4",
     "d2l-button": "^4.7.3",
-    "d2l-card": "^4.1.11",
+    "d2l-card": "^4.1.15",
     "d2l-dropdown": "^6.6.1",
     "d2l-fetch": "Brightspace/d2l-fetch#^1.8.0",
     "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^5.0.0",

--- a/components/d2l-enrollment-card/d2l-enrollment-card.html
+++ b/components/d2l-enrollment-card/d2l-enrollment-card.html
@@ -198,7 +198,6 @@ Polymer-based web component for a course/enrollment card.
 		</style>
 
 		<d2l-card
-			subtle
 			disabled$=[[disabled]]
 			href="[[_organizationHomepageUrl]]"
 			text="[[_accessibilityDataToString(_accessibilityData)]]">


### PR DESCRIPTION
* the new version of `d2l-card` includes the y-translation and box-shadow on hover
