### PR TITLE
Resets the state if the enrollment changes.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "d2l-menu": "^1.1.0",
     "d2l-offscreen": "^3.0.3",
     "d2l-organization-hm-behavior": "Brightspace/organization-hm-behavior#^2.0.1",
-    "d2l-organizations": "BrightspaceHypermediaComponents/organizations#^0.1.7-hybrid",
+    "d2l-organizations": "BrightspaceHypermediaComponents/organizations#^0.1.8-hybrid",
     "d2l-status-indicator": "^2.0.0",
     "iron-a11y-announcer": "^2.0.0",
     "polymer": "1 - 2",

--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "d2l-menu": "^1.1.0",
     "d2l-offscreen": "^3.0.3",
     "d2l-organization-hm-behavior": "Brightspace/organization-hm-behavior#^2.0.1",
-    "d2l-organizations": "BrightspaceHypermediaComponents/organizations#^0.1.5-hybrid",
+    "d2l-organizations": "BrightspaceHypermediaComponents/organizations#^0.1.7-hybrid",
     "d2l-status-indicator": "^2.0.0",
     "iron-a11y-announcer": "^2.0.0",
     "polymer": "1 - 2",

--- a/components/d2l-enrollment-card/d2l-enrollment-card.html
+++ b/components/d2l-enrollment-card/d2l-enrollment-card.html
@@ -602,6 +602,8 @@ Polymer-based web component for a course/enrollment card.
 					return;
 				}
 
+				this._resetState();
+
 				this._enrollment = enrollment;
 				this._pinned = enrollment.hasClass(this.HypermediaClasses.enrollments.pinned);
 				this._organizationUrl = enrollment.getLinkByRel(this.HypermediaRels.organization).href;
@@ -873,6 +875,15 @@ Polymer-based web component for a course/enrollment card.
 				} else {
 					this.removeAttribute('started-inactive');
 				}
+			},
+			_resetState: function() {
+				this._setCompleted(false);
+				this._setClosed(false);
+				this._setDisabled(false);
+				this._setOverdue(false);
+				this._setInactive(false);
+				this._newEnrollment = false;
+				this._setBadgeText();
 			}
 		});
 	</script>

--- a/test/d2l-enrollment-card/d2l-enrollment-card.js
+++ b/test/d2l-enrollment-card/d2l-enrollment-card.js
@@ -471,7 +471,7 @@ describe('d2l-enrollment-card', () => {
 
 		it('No Badge', () => {
 			expect(component._badgeText).to.be.null;
-			expect(component._badgeState).to.be.undefined;
+			expect(component._badgeState).to.be.null;
 			var badge = component.$$('d2l-status-indicator');
 			expect(badge.hasAttribute('hidden')).to.be.true;
 		});

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -25,7 +25,7 @@
         {
           "browserName": "safari",
           "platform": "OS X 10.13",
-          "version": ""
+          "version": "11.1"
         },
         {
           "browserName": "microsoftedge",


### PR DESCRIPTION
Enrollment cards wouldn't reset their state. So if the sort order changed, the card would get a new `href` but all the badges would stay. So new course information but with old inactive badge