### PR TITLE
Completed to Complete.

### DIFF
--- a/components/d2l-enrollment-card/lang/ar.json
+++ b/components/d2l-enrollment-card/lang/ar.json
@@ -1,7 +1,7 @@
 {
    "changeImage" : "تغيير الصورة",
    "closed" : "مغلق",
-   "completed" : "تم الإكمال",
+   "completed": "Complete",
    "courseOfferingInformation" : "معلومات مضمون المقرر التعليمي",
    "coursePinButton" : "{course} is pinned. إلغاء تثبيت المقرر التعليمي",
    "courseSettings" : "إعدادات المقرر التعليمي {course}",

--- a/components/d2l-enrollment-card/lang/de.json
+++ b/components/d2l-enrollment-card/lang/de.json
@@ -1,7 +1,7 @@
 {
    "changeImage" : "Bild ändern",
    "closed" : "Geschlossen",
-   "completed" : "Abgeschlossen",
+   "completed": "Complete",
    "courseOfferingInformation" : "Informationen zum Kursangebot",
    "coursePinButton" : "{course} ist angeheftet. Kurs lösen",
    "courseSettings" : "Kurseinstellungen für {course}",

--- a/components/d2l-enrollment-card/lang/es.json
+++ b/components/d2l-enrollment-card/lang/es.json
@@ -1,7 +1,7 @@
 {
    "changeImage" : "Cambiar imagen",
    "closed" : "Cerrado",
-   "completed" : "Completado",
+   "completed": "Complete",
    "courseOfferingInformation" : "Información de oferta de cursos",
    "coursePinButton" : "{course} está anclado. Desanclar curso",
    "courseSettings" : "Configuración del curso {course}",

--- a/components/d2l-enrollment-card/lang/fi.json
+++ b/components/d2l-enrollment-card/lang/fi.json
@@ -8,7 +8,7 @@
   "pinActionResult": "{course} has been pinned",
   "unpin": "Unpin",
   "unpinActionResult": "{course} has been unpinned",
-  "completed": "Completed",
+  "completed": "Complete",
   "overdue": "Overdue",
   "new": "New",
   "disabled": "Disabled",

--- a/components/d2l-enrollment-card/lang/fr.json
+++ b/components/d2l-enrollment-card/lang/fr.json
@@ -1,7 +1,7 @@
 {
    "changeImage" : "Modifier l'image",
    "closed" : "Fermé",
-   "completed" : "Terminé",
+   "completed": "Complete",
    "courseOfferingInformation" : "Information sur l'offre de cours",
    "coursePinButton" : "Le cours {course} est épinglé. Annuler l'épinglage du cours",
    "courseSettings" : "Paramètres du cours {course}",

--- a/components/d2l-enrollment-card/lang/ja.json
+++ b/components/d2l-enrollment-card/lang/ja.json
@@ -1,7 +1,7 @@
 {
    "changeImage" : "イメージの変更",
    "closed" : "クローズ",
-   "completed" : "完了",
+   "completed": "Complete",
    "courseOfferingInformation" : "コース内容情報",
    "coursePinButton" : "{course} は固定されています。コースの固定解除",
    "courseSettings" : "{course} コースの設定",

--- a/components/d2l-enrollment-card/lang/ko.json
+++ b/components/d2l-enrollment-card/lang/ko.json
@@ -1,7 +1,7 @@
 {
    "changeImage" : "이미지 변경",
    "closed" : "닫힘",
-   "completed" : "완료됨",
+   "completed": "Complete",
    "courseOfferingInformation" : "개설 강의 정보",
    "coursePinButton" : "{course} 강의가 고정되었습니다. 강의 고정 취소",
    "courseSettings" : "{course} 강의 설정",

--- a/components/d2l-enrollment-card/lang/nl.json
+++ b/components/d2l-enrollment-card/lang/nl.json
@@ -1,7 +1,7 @@
 {
    "changeImage" : "Afbeelding wijzigen",
    "closed" : "Gesloten",
-   "completed" : "Voltooid",
+   "completed": "Complete",
    "courseOfferingInformation" : "Informatie cursuseditie",
    "coursePinButton" : "{course} is vastgepind. Cursus losmaken",
    "courseSettings" : "{course}-cursusinstellingen",

--- a/components/d2l-enrollment-card/lang/pt.json
+++ b/components/d2l-enrollment-card/lang/pt.json
@@ -1,7 +1,7 @@
 {
    "changeImage" : "Alterar imagem",
    "closed" : "Fechado",
-   "completed" : "Concluído",
+   "completed": "Complete",
    "courseOfferingInformation" : "Informações de Oferta de Curso",
    "coursePinButton" : "{course} está fixado. Desafixar curso",
    "courseSettings" : "Configurações de curso de {course}",

--- a/components/d2l-enrollment-card/lang/sv.json
+++ b/components/d2l-enrollment-card/lang/sv.json
@@ -1,7 +1,7 @@
 {
    "changeImage" : "Ändra bild",
    "closed" : "Stängd",
-   "completed" : "Slutförd",
+   "completed": "Complete",
    "courseOfferingInformation" : "Information om kursutbud",
    "coursePinButton" : "{course} är markerad. Avmarkera kurs",
    "courseSettings" : "Kursinställningar för {course}",

--- a/components/d2l-enrollment-card/lang/tr.json
+++ b/components/d2l-enrollment-card/lang/tr.json
@@ -1,7 +1,7 @@
 {
    "changeImage" : "Görüntüyü Değiştir",
    "closed" : "Kapandı",
-   "completed" : "Tamamlandı",
+   "completed": "Complete",
    "courseOfferingInformation" : "Ders Önerisi Bilgileri",
    "coursePinButton" : "{course} dersi sabitlendi. Dersin sabitlemesini geri al",
    "courseSettings" : "{course} dersi ayarları",

--- a/components/d2l-enrollment-card/lang/zh-tw.json
+++ b/components/d2l-enrollment-card/lang/zh-tw.json
@@ -1,7 +1,7 @@
 {
    "changeImage" : "變更影像",
    "closed" : "已關閉",
-   "completed" : "已完成",
+   "completed": "Complete",
    "courseOfferingInformation" : "開課項目資訊",
    "coursePinButton" : "{course} 已置頂。將課程取消置頂",
    "courseSettings" : "{course} 課程設定",

--- a/components/d2l-enrollment-card/lang/zh.json
+++ b/components/d2l-enrollment-card/lang/zh.json
@@ -1,7 +1,7 @@
 {
    "changeImage" : "更改图像",
    "closed" : "已关闭",
-   "completed" : "已完成",
+   "completed": "Complete",
    "courseOfferingInformation" : "课程优惠信息",
    "coursePinButton" : "{course} 已锁定。取消锁定课程",
    "courseSettings" : "{course} 课程设置",


### PR DESCRIPTION
The status indicator for a course being complete uses the term 'Completed' in my courses, and it should be 'Complete' to be consistent.