### PR TITLE
DE34146-fix crazy callback chains

### DIFF
--- a/components/d2l-enrollment-card/d2l-enrollment-card.js
+++ b/components/d2l-enrollment-card/d2l-enrollment-card.js
@@ -595,6 +595,9 @@ Polymer({
 			}.bind(this), 1000);
 		}.bind(this), 1000);
 	},
+	_loadEnrollmentForPinning: function(enrollment) {
+		return this._loadEnrollmentData(true, enrollment);
+	},
 	_loadEnrollmentData: function(load, enrollment) {
 		this._resetState();
 		if (!load || !enrollment) {
@@ -783,7 +786,7 @@ Polymer({
 			text: this.localize(localizeKey, 'course', this._organization.properties.name)
 		}, { bubbles: true });
 
-		return this.performSirenAction(pinAction).then(this._loadEnrollmentData.bind(this)).then(function() {
+		return this.performSirenAction(pinAction).then(this._loadEnrollmentForPinning.bind(this)).then(function() {
 			// Wait until after PUT has finished to fire, so that
 			// listeners are guaranteed to fetch updated entity
 			this.fire('d2l-course-pinned-change', {


### PR DESCRIPTION
I think the callback chain is a bug since `performSirenAction` only returns single `enrollment`, at the same time, I don't see any misbehavior caused by this issue, so I'm not sure if we need this fix. I tested the fix, I observed the same with and without the change when pinning.