### PR TITLE
Add stickiness to the enrollment summary view progress bar

### DIFF
--- a/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view.js
+++ b/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view.js
@@ -85,6 +85,11 @@ class D2lEnrollmentSummaryView extends EnrollmentsLocalize(EntityMixin(PolymerEl
 					overflow: hidden;
 					padding: 2.45rem 6.75rem 1rem 6.75rem;
 				}
+				.desv-sticky-header {
+					position: sticky;
+					top: 0;
+					z-index: 1000;
+				}
 				.desv-title-bar h1 {
 					@apply --d2l-heading-1;
 					color: var(--d2l-color-ferrite);
@@ -196,6 +201,8 @@ class D2lEnrollmentSummaryView extends EnrollmentsLocalize(EntityMixin(PolymerEl
 					<h1> [[_title]] </h1>
 					<d2l-enrollment-summary-view-tag-list list=[[_tags]]></d2l-enrollment-summary-view-tag-list>
 				</div>
+			</div>
+			<div class="desv-header desv-sticky-header">
 				<d2l-enrollment-summary-view-layout>
 					<div class="desv-progress" slot="first-column">
 						<d2l-enrollment-summary-view-meter

--- a/demo/d2l-enrollment-summary-view/d2l-enrollment-summary-view-demo.html
+++ b/demo/d2l-enrollment-summary-view/d2l-enrollment-summary-view-demo.html
@@ -45,6 +45,7 @@
 				</custom-style>
 			`;
 			document.body.appendChild($_documentContainer.content);
+			window.D2L.Siren.WhitelistBehavior._inTestMode = true;
 		</script>
 	</head>
 	<body class="d2l-typography">

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "d2l-status-indicator": "BrightspaceUI/status-indicator#semver:^3",
     "d2l-tooltip": "BrightspaceUI/tooltip#semver:^3",
     "intersection-observer": "^0.5.1",
+    "lie": "^3.3.0",
     "siren-sdk": "BrightspaceHypermediaComponents/siren-sdk#semver:^1"
   }
 }


### PR DESCRIPTION
# Changes
1. This pull request adds stickiness to the `d2l-enrollment-summary-view`'s progress bar so that the progress bar stays pinned at the top of the page when scrolling past it.
1. Add a dependency on `lie` to resolve the missing import error during CI runs due to `lie` no longer being brought in implicitly as a sub-dependency.