### PR TITLE
Change the d2l-enrollment-detail-card skeleton to use a pulse animation

### DIFF
--- a/components/d2l-enrollment-detail-card/d2l-enrollment-detail-card.js
+++ b/components/d2l-enrollment-detail-card/d2l-enrollment-detail-card.js
@@ -91,9 +91,10 @@ class D2lEnrollmentDetailCard extends mixinBehaviors([
 					margin: 0.45rem 0;
 					width: 95%;
 				}
-				@keyframes loadingShimmer {
-					0% { transform: translate3d(-100%, 0, 0); }
-					100% { transform: translate3d(100%, 0, 0); }
+				@keyframes loadingPulse {
+					0% { background-color: var(--d2l-color-sylvite); }
+					50% { background-color: var(--d2l-color-regolith); }
+					100% { background-color: var(--d2l-color-sylvite); }
 				}
 				.dedc-image {
 					background-color: var(--d2l-color-regolith);
@@ -104,8 +105,9 @@ class D2lEnrollmentDetailCard extends mixinBehaviors([
 					position: relative;
 					width: 220px;
 				}
-				.dedc-image-shimmer {
-					background-color: var(--d2l-color-regolith);
+				.dedc-image-pulse {
+					animation: loadingPulse 1.8s linear infinite;
+					background-color: var(--d2l-color-sylvite);
 					display: var(--d2l-enrollment-detail-card-image-shimmer-display);
 					height: 100%;
 					left: 0;
@@ -116,17 +118,6 @@ class D2lEnrollmentDetailCard extends mixinBehaviors([
 				}
 				.dedc-image d2l-course-image {
 					height: 100%;
-					width: 100%;
-				}
-				.dedc-image-shimmer::after {
-					animation: loadingShimmer 1.5s ease-in-out infinite;
-					background: linear-gradient(90deg, rgba(249, 250, 251, 0.1), rgba(114, 119, 122, 0.1), rgba(249, 250, 251, 0.1));
-					background-color: var(--d2l-color-regolith);
-					content: '';
-					height: 100%;
-					left: 0;
-					position: absolute;
-					top: 0;
 					width: 100%;
 				}
 				.dedc-base-info-container {
@@ -181,6 +172,7 @@ class D2lEnrollmentDetailCard extends mixinBehaviors([
 					width: 5rem;
 				}
 				.dedc-text-placeholder {
+					animation: loadingPulse 1.8s linear infinite;
 					background-color: var(--d2l-color-sylvite);
 					border-radius: 4px;
 				}
@@ -285,7 +277,7 @@ class D2lEnrollmentDetailCard extends mixinBehaviors([
 						<span class="dedc-link-text">[[_title]]</span>
 					</a>
 					<div class="dedc-image">
-						<div class="dedc-image-shimmer"></div>
+						<div class="dedc-image-pulse"></div>
 						<d2l-organization-image href="[[_organizationUrl]]" token="[[token]]"></d2l-organization-image>
 					</div>
 					<div  class="dedc-base-info-container">

--- a/demo/d2l-enrollment-detail-card/d2l-enrollment-detail-card-demo.html
+++ b/demo/d2l-enrollment-detail-card/d2l-enrollment-detail-card-demo.html
@@ -55,6 +55,7 @@
 				</custom-style>
 			`;
 			document.body.appendChild($_documentContainer.content);
+			window.D2L.Siren.WhitelistBehavior._inTestMode = true;
 		</script>
 	</head>
 	<body class="d2l-typography">


### PR DESCRIPTION
# Changes

This pull request updates the `d2l-enrollment-detail-card` to show pulse every 1.8 seconds instead of shimmering. The animation now also applies to the text placeholders instead of just the image placeholder.