### PR TITLE
Add d2l-enrollment-detail-card loading states

### DIFF
--- a/test/d2l-enrollment-detail-card/d2l-enrollment-detail-card.js
+++ b/test/d2l-enrollment-detail-card/d2l-enrollment-detail-card.js
@@ -44,4 +44,83 @@ describe('d2l-enrollment-detail-card', () => {
 			done();
 		});
 	});
+
+	describe('Check if loaded events fire.', () => {
+		beforeEach(done => {
+			component = fixture('d2l-enrollment-detail-card-fixture');
+			afterNextRender(component, done);
+		});
+
+		it('should fire the text loaded event', (done) => {
+			var eventSpy = sandbox.spy();
+			component.addEventListener('d2l-enrollment-detail-card-text-loaded', eventSpy);
+
+			component._entity = enrollmentEntity;
+
+			setTimeout(() => {
+				sinon.assert.called(eventSpy);
+				done();
+			});
+
+		});
+
+		it('should fire the image loaded event', (done) => {
+			var eventSpy = sandbox.spy();
+			component.addEventListener('d2l-enrollment-detail-card-image-loaded', eventSpy);
+
+			component.dispatchEvent(new CustomEvent('d2l-organization-image-loaded', {
+				bubbles: true,
+				composed: true
+			}));
+			setTimeout(() => {
+				sinon.assert.called(eventSpy);
+				done();
+			});
+
+		});
+
+	});
+
+	describe('Check if content is revealed after the reveal timeout has passed.', () => {
+		beforeEach(done => {
+			component = fixture('d2l-enrollment-detail-card-fixture');
+			afterNextRender(component, done);
+		});
+
+		it('should reveal loaded text content', (done) => {
+			component._entity = enrollmentEntity;
+
+			setTimeout(() => {
+				expect(component._forceShowText).to.equal(true);
+				done();
+			}, component._revealTimeoutMs);
+		});
+
+		it('should not reveal loading text content', (done) => {
+			setTimeout(() => {
+				expect(component._forceShowText).to.equal(false);
+				done();
+			}, component._revealTimeoutMs);
+		});
+
+		it('should reveal loaded image content', (done) => {
+			component.dispatchEvent(new CustomEvent('d2l-organization-image-loaded', {
+				bubbles: true,
+				composed: true
+			}));
+
+			setTimeout(() => {
+				expect(component._forceShowImage).to.equal(true);
+				done();
+			}, component._revealTimeoutMs);
+		});
+
+		it('should not reveal loading image content', (done) => {
+			setTimeout(() => {
+				expect(component._forceShowImage).to.equal(false);
+				done();
+			}, component._revealTimeoutMs);
+		});
+
+	});
 });


### PR DESCRIPTION
# Changes
1. Events
    -  A `d2l-enrollment-detail-card-image-loaded` event is fired when the card image loads.
    - A `d2l-enrollment-detail-card-text-loaded` event is fired when the card text loads.
2. A reveal timeout was added to show the image and text after 2 seconds even if the `--d2l-enrollment-detail-card-loading` style has been applied to force the card to show its content even if the entire page doesn't load successfully.