### PR TITLE
Adding hide-pinning to d2l-enrollments-hero-banner, and ensuring hide…

### DIFF
--- a/components/d2l-enrollment-card/d2l-enrollment-card.js
+++ b/components/d2l-enrollment-card/d2l-enrollment-card.js
@@ -520,7 +520,6 @@ class EnrollmentCard extends mixinBehaviors([
 	}
 
 	_shouldHideUnpinOption(pinned) {
-		// console.log(`hide unpinned ${this.hidePinning} ${pinned}`);
 		return this.hidePinning || !pinned;
 	}
 

--- a/components/d2l-enrollment-collection-widget/d2l-enrollment-collection-widget.js
+++ b/components/d2l-enrollment-collection-widget/d2l-enrollment-collection-widget.js
@@ -54,7 +54,7 @@ class EnrollmentCollectionWidget extends EntityMixin(PolymerElement) {
 				}
 			</style>
 			<template is="dom-if" if="[[!_hasTwoEnrollments]]">
-				<d2l-enrollment-hero-banner href="[[_enrollmentHeroHref]]" token="[[token]]"></d2l-enrollment-hero-banner>
+				<d2l-enrollment-hero-banner href="[[_enrollmentHeroHref]]" token="[[token]]" hide-pinning></d2l-enrollment-hero-banner>
 				<div class="decw-flex">
 					<template is="dom-repeat"  items="[[_enrollmentsHref]]">
 						<d2l-enrollment-card href="[[item]]" token="[[token]]"
@@ -62,20 +62,22 @@ class EnrollmentCollectionWidget extends EntityMixin(PolymerElement) {
 								show-dropbox-unread-feedback
 								show-ungraded-quiz-attempts
 								show-unread-discussion-messages
-								show-unread-dropbox-submissions>
+								show-unread-dropbox-submissions
+								hide-pinning>
 						</d2l-enrollment-card>
 					</template>
 				</div>
 			</template>
 			<template is="dom-if" if="[[_hasTwoEnrollments]]">
 				<div class="decw-flex-two">
-					<d2l-enrollment-hero-banner href="[[_enrollmentHeroHref]]" token="[[token]]"></d2l-enrollment-hero-banner>
+					<d2l-enrollment-hero-banner href="[[_enrollmentHeroHref]]" token="[[token]]" hide-pinning></d2l-enrollment-hero-banner>
 					<d2l-enrollment-card href="[[_enrollmentsHref.0]]" token="[[token]]"
 							show-unattempted-quizzes
 							show-dropbox-unread-feedback
 							show-ungraded-quiz-attempts
 							show-unread-discussion-messages
-							show-unread-dropbox-submissions>
+							show-unread-dropbox-submissions
+							hide-pinning>
 					</d2l-enrollment-card>
 				</div>
 			</template>

--- a/components/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
+++ b/components/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
@@ -251,22 +251,24 @@ class EnrollmentHeroBanner extends EnrollmentsLocalize(EntityMixin(PolymerElemen
 						<div class="dehb-base-info">
 							<div class="dehb-title"><h2>[[_organizationName]]</h2></div>
 							<div class="dehb-context-menu">
-								<d2l-dropdown-more text="[[_courseSettingsLabel]]" visible-on-ancestor>
-									<d2l-dropdown-menu>
-										<d2l-menu label="[[_courseSettingsLabel]]">
-											<d2l-menu-item-link hidden$="[[!_canAccessCourseInfo]]" text="[[localize('courseOfferingInformation')]]" href="[[_courseInfoUrl]]">
-											</d2l-menu-item-link>
-											<d2l-menu-item on-d2l-menu-item-select="_launchCourseImageSelector" hidden$="[[!_canChangeCourseImage]]" text="[[localize('changeImage')]]">
-											</d2l-menu-item>
-											<d2l-menu-item on-d2l-menu-item-select="_pinClickHandler" hidden$="[[_pinned]]" text="[[localize('pin')]]">
-											</d2l-menu-item>
-											<d2l-menu-item on-d2l-menu-item-select="_pinClickHandler" hidden$="[[!_pinned]]" text="[[localize('unpin')]]">
-											</d2l-menu-item>
-									</d2l-dropdown-menu>
-								</d2l-dropdown-more>
+								<template is="dom-if" if="[[_shouldShowDropDown(_canAccessCourseInfo, _canChangeCourseImage)]]">
+									<d2l-dropdown-more text="[[_courseSettingsLabel]]" visible-on-ancestor>
+										<d2l-dropdown-menu>
+											<d2l-menu label="[[_courseSettingsLabel]]">
+												<d2l-menu-item-link hidden$="[[!_canAccessCourseInfo]]" text="[[localize('courseOfferingInformation')]]" href="[[_courseInfoUrl]]">
+												</d2l-menu-item-link>
+												<d2l-menu-item on-d2l-menu-item-select="_launchCourseImageSelector" hidden$="[[!_canChangeCourseImage]]" text="[[localize('changeImage')]]">
+												</d2l-menu-item>
+												<d2l-menu-item on-d2l-menu-item-select="_pinClickHandler" hidden$="[[_shouldHidePinOption(_pinned)]]" text="[[localize('pin')]]">
+												</d2l-menu-item>
+												<d2l-menu-item on-d2l-menu-item-select="_pinClickHandler" hidden$="[[_shouldHideUnpinOption(_pinned)]]" text="[[localize('unpin')]]">
+												</d2l-menu-item>
+										</d2l-dropdown-menu>
+									</d2l-dropdown-more>
 
-								<d2l-button-icon hidden$="[[!_pinned]]" text="[[_pinButtonLabel]]" icon="d2l-tier1:pin-filled" on-tap="_pinClickHandler" on-keypress="_pinPressHandler">
-								</d2l-button-icon>
+									<d2l-button-icon hidden$="[[_shouldHideUnpinOption(_pinned)]]" text="[[_pinButtonLabel]]" icon="d2l-tier1:pin-filled" on-tap="_pinClickHandler" on-keypress="_pinPressHandler">
+									</d2l-button-icon>
+								</template>
 							</div>
 							<div class="dehb-tag-container dehb-tag-placeholder-container">
 								<div class="dehb-text-placeholder dehb-tag-placeholder"></div>
@@ -306,6 +308,10 @@ class EnrollmentHeroBanner extends EnrollmentsLocalize(EntityMixin(PolymerElemen
 				computed: '_computeDisabled(_organizationHomepageUrl)',
 				reflectToAttribute: true,
 				readOnly: true
+			},
+			hidePinning: {
+				type: Boolean,
+				value: false
 			},
 			_organization: Object,
 			_organizationName: String,
@@ -417,6 +423,18 @@ class EnrollmentHeroBanner extends EnrollmentsLocalize(EntityMixin(PolymerElemen
 		} else {
 			this.removeAttribute('pinned');
 		}
+	}
+
+	_shouldHidePinOption(pinned) {
+		return this.hidePinning || pinned;
+	}
+
+	_shouldHideUnpinOption(pinned) {
+		return this.hidePinning || !pinned;
+	}
+
+	_shouldShowDropDown(canAccessCourseInfo, canChangeCourseImage) {
+		return !this.hidePinning || canAccessCourseInfo || canChangeCourseImage;
 	}
 }
 

--- a/test/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
+++ b/test/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
@@ -9,7 +9,8 @@ describe('d2l-enrollment-hero-banner', () => {
 		onOrganizationChangeStub,
 		pinStub,
 		pinActionStub,
-		organizationHasActionByNameStub;
+		organizationHasActionByNameStub,
+		courseInfoUrlStub;
 
 	beforeEach(() => {
 		sandbox = sinon.sandbox.create();
@@ -18,6 +19,7 @@ describe('d2l-enrollment-hero-banner', () => {
 		onOrganizationChangeStub = sinon.stub();
 		pinStub = sinon.stub();
 		organizationHasActionByNameStub = sinon.stub();
+		courseInfoUrlStub = sinon.stub();
 
 		enrollmentEntity = {
 			organizationHref: function() { return 'organizationHref'; },
@@ -37,7 +39,7 @@ describe('d2l-enrollment-hero-banner', () => {
 				getLinkByRel: function() { return { href: 'organizationHref' }; }
 			},
 			name: function() { return 'name'; },
-			courseInfoUrl: function() { return 'courseInfoUrl'; },
+			courseInfoUrl: courseInfoUrlStub,
 			organizationHomepageUrl: function() { return 'organizationHomepageUrl'; },
 			canChangeCourseImage: organizationHasActionByNameStub,
 		};
@@ -46,6 +48,7 @@ describe('d2l-enrollment-hero-banner', () => {
 
 		pinStub.returns(true);
 		organizationHasActionByNameStub.returns(true);
+		courseInfoUrlStub.returns('courseInfoUrl');
 		pinActionStub = sandbox.stub(component, 'performSirenAction');
 		pinActionStub.withArgs(sinon.match.defined).returns(Promise.resolve(enrollmentEntity._entity));
 	});
@@ -110,37 +113,49 @@ describe('d2l-enrollment-hero-banner', () => {
 	});
 
 	describe('Pinning functionality', () => {
-		it('should have a visible "Unpin" menu item when pinned', () => {
+		it('should have a visible "Unpin" menu item when pinned', done => {
 			component._entity = enrollmentEntity;
 
-			var unpinMenuItem = component.$$('d2l-menu-item.d2l-menu-item-last');
+			afterNextRender(component, () => {
+				var unpinMenuItem = component.$$('d2l-menu-item.d2l-menu-item-last');
 
-			expect(unpinMenuItem).to.not.be.null;
-			expect(unpinMenuItem.text).to.equal('Unpin');
+				expect(unpinMenuItem).to.not.be.null;
+				expect(unpinMenuItem.text).to.equal('Unpin');
+				done();
+			});
 		});
 
-		it('should have a visible "Pin" menu item when pinned', () => {
+		it('should have a visible "Pin" menu item when pinned', done => {
 			pinStub.returns(false);
 			component._entity = enrollmentEntity;
 
-			var pinMenuItem = component.$$('d2l-menu-item.d2l-menu-item-last');
-			expect(pinMenuItem).to.not.be.null;
-			expect(pinMenuItem.text).to.equal('Pin');
+			afterNextRender(component, () => {
+				var pinMenuItem = component.$$('d2l-menu-item.d2l-menu-item-last');
+				expect(pinMenuItem).to.not.be.null;
+				expect(pinMenuItem.text).to.equal('Pin');
+				done();
+			});
 		});
 
-		it('should have a visible pinned button when pinned', () => {
+		it('should have a visible pinned button when pinned', done => {
 			component._entity = enrollmentEntity;
 
-			var pinButton = component.$$('.dehb-context-menu > d2l-button-icon');
-			expect(pinButton.hasAttribute('hidden')).to.be.false;
+			afterNextRender(component, () => {
+				var pinButton = component.$$('.dehb-context-menu > d2l-button-icon');
+				expect(pinButton.hasAttribute('hidden')).to.be.false;
+				done();
+			});
 		});
 
-		it('should hide the pinned button when unpinned', () => {
+		it('should hide the pinned button when unpinned', done => {
 			pinStub.returns(false);
 			component._entity = enrollmentEntity;
 
-			var pinButton = component.$$('.dehb-context-menu > d2l-button-icon');
-			expect(pinButton.hasAttribute('hidden')).to.be.true;
+			afterNextRender(component, () => {
+				var pinButton = component.$$('.dehb-context-menu > d2l-button-icon');
+				expect(pinButton.hasAttribute('hidden')).to.be.true;
+				done();
+			});
 		});
 
 		it('should set the update action parameters correctly and call the pinning API', done => {
@@ -165,6 +180,36 @@ describe('d2l-enrollment-hero-banner', () => {
 			});
 
 			component._pinClickHandler();
+		});
+
+		it('should hide pinning options when hidePinning=true', done => {
+			component.hidePinning = true;
+			component._entity = enrollmentEntity;
+			afterNextRender(component, () => {
+				var menuItems = component.root.querySelectorAll('d2l-menu-item:not([hidden])');
+				var changeImageMenuItem = menuItems[menuItems.length - 1];
+				var pinButton = component.$$('d2l-button-icon');
+				expect(pinButton).to.not.be.null;
+				expect(pinButton.hasAttribute('hidden')).to.be.true;
+				expect(changeImageMenuItem).to.not.be.null;
+				expect(changeImageMenuItem.text).to.equal('Change Image');
+				done();
+			});
+		});
+
+		it('should hide menu when no options are available', done => {
+			component.hidePinning = true;
+			organizationHasActionByNameStub.returns(false);
+			courseInfoUrlStub.returns(null);
+
+			component._entity = enrollmentEntity;
+			setTimeout(() => {
+				var d2lMenu = component.$$('d2l-menu');
+				var pinButton = component.$$('d2l-button-icon');
+				expect(pinButton).to.be.null;
+				expect(d2lMenu).to.be.null;
+				done();
+			});
 		});
 
 	});


### PR DESCRIPTION
…-pinning=true for MLW

Assumptions:
- MLW for Learning Paths uses `d2l-enrollment-collection-widget`
- We want a similar hide-pinning experience for the hero-banner.