### PR TITLE
Summary View layout and text wrapping

### DIFF
--- a/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view-layout.js
+++ b/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view-layout.js
@@ -15,7 +15,7 @@ class D2lEnrollmentSummaryViewLayout extends PolymerElement {
 				.desvl-flex {
 					display: flex;
 					justify-content: center;
-					margin: 0 6.75rem;
+					margin: 0 1.5rem;
 					max-width: 1230px;
 				}
 				.desvl-first-column {
@@ -33,12 +33,12 @@ class D2lEnrollmentSummaryViewLayout extends PolymerElement {
 				@media only screen and (max-width: 929px) {
 					.desvl-center {
 						margin: auto;
-						max-width: 692px;
+						max-width: 920px;
 					}
 					.desvl-flex {
 						flex-direction: column;
 						margin: 0 1.15rem;
-						max-width: 675px;
+						max-width: 903px;
 					}
 					.desvl-first-column {
 						border-right: none;

--- a/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view.js
+++ b/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view.js
@@ -85,7 +85,7 @@ class D2lEnrollmentSummaryView extends EnrollmentsLocalize(EntityMixin(PolymerEl
 					margin: auto;
 					max-width: 1230px;
 					overflow: hidden;
-					padding: 2.45rem 6.75rem 1rem 6.75rem;
+					padding: 2.45rem 1.5rem 1rem 1.5rem;
 					position: relative;
 				}
 				.desv-sticky-header {
@@ -123,11 +123,13 @@ class D2lEnrollmentSummaryView extends EnrollmentsLocalize(EntityMixin(PolymerEl
 					width: 100%;
 				}
 				.desv-continue {
+					display: flex;
 					position: relative;
 				}
 				.desv-continue span {
 					@apply --d2l-body-small-text;
 					letter-spacing: 0.3px;
+					margin-left: 0.2rem;
 				}
 				.desv-course-list {
 					margin: 2.5rem 0 0 0;
@@ -163,7 +165,7 @@ class D2lEnrollmentSummaryView extends EnrollmentsLocalize(EntityMixin(PolymerEl
 					}
 					.desv-title-bar {
 						flex-direction: column;
-						max-width: 680px;
+						max-width: 908px;
 						padding-bottom: 0.8rem;
 						padding-top: 1.5rem;
 						padding: 0.9rem;


### PR DESCRIPTION
- Updated the position of the summary to match nav
- Module text beside continue wraps better.

![image](https://user-images.githubusercontent.com/13232226/61960398-5b666000-af93-11e9-92fd-b9d0b579387b.png)

![image](https://user-images.githubusercontent.com/13232226/61960434-73d67a80-af93-11e9-8651-641f1d05e44f.png)
