### PR TITLE
Add RTL fixes for the d2l-enollment-summary-view and associated sub-components

### DIFF
--- a/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view-layout.js
+++ b/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view-layout.js
@@ -1,10 +1,11 @@
 import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
+import { DirMixin } from '@polymer/polymer/lib/mixins/dir-mixin.js';
 
 /**
  * @customElement
  * @polymer
  */
-class D2lEnrollmentSummaryViewLayout extends PolymerElement {
+class D2lEnrollmentSummaryViewLayout extends DirMixin(PolymerElement) {
 	static get template() {
 		return html`
 			<style>
@@ -30,6 +31,14 @@ class D2lEnrollmentSummaryViewLayout extends PolymerElement {
 					overflow: hidden;
 					padding: 0 0 0 1.5rem;
 				}
+				:host(:dir(rtl)) .desvl-first-column {
+					border-left: var(--d2l-enrollment-summary-view-tag-layout-inner-border, none);
+					border-right: none;
+					padding: 0 0 0 1.5rem;
+				}
+				:host(:dir(rtl)) .desvl-second-column {
+					padding: 0 1.5rem 0 0;
+				}
 				@media only screen and (max-width: 929px) {
 					.desvl-center {
 						margin: auto;
@@ -40,12 +49,14 @@ class D2lEnrollmentSummaryViewLayout extends PolymerElement {
 						margin: 0 1.15rem;
 						max-width: 903px;
 					}
-					.desvl-first-column {
+					.desvl-first-column,
+					:host(:dir(rtl)) .desvl-first-column {
 						border-right: none;
 						overflow: visible;
 						padding: 0;
 					}
-					.desvl-second-column {
+					.desvl-second-column,
+					:host(:dir(rtl)) .desvl-second-column {
 						overflow: visible;
 						padding: 0;
 					}

--- a/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view-meter.js
+++ b/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view-meter.js
@@ -1,11 +1,12 @@
 import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
 import 'd2l-typography/d2l-typography-shared-styles.js';
+import { DirMixin } from '@polymer/polymer/lib/mixins/dir-mixin.js';
 
 /**
  * @customElement
  * @polymer
  */
-class D2lEnrollmentSummaryViewMeter extends PolymerElement {
+class D2lEnrollmentSummaryViewMeter extends DirMixin(PolymerElement) {
 	static get template() {
 		return html`
 			<style>
@@ -32,6 +33,10 @@ class D2lEnrollmentSummaryViewMeter extends PolymerElement {
 					left: 0;
 					top: 0;
 					background-color: var(--d2l-color-celestine);
+				}
+
+				:host(:dir(rtl)) .desvm-linear-inner-bar {
+					right: 0;
 				}
 			</style>
 			<div

--- a/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view-tag-list.js
+++ b/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view-tag-list.js
@@ -1,11 +1,12 @@
 import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
 import 'd2l-typography/d2l-typography-shared-styles.js';
+import { DirMixin } from '@polymer/polymer/lib/mixins/dir-mixin.js';
 
 /**
  * @customElement
  * @polymer
  */
-class D2lEnrollmentSummaryViewTagList extends PolymerElement {
+class D2lEnrollmentSummaryViewTagList extends DirMixin(PolymerElement) {
 	static get template() {
 		return html`
 			<style>

--- a/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view.js
+++ b/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view.js
@@ -112,6 +112,9 @@ class D2lEnrollmentSummaryView extends EnrollmentsLocalize(EntityMixin(PolymerEl
 				.desv-button {
 					margin: 0.5rem 0.6rem 0.6rem 0;
 				}
+				:host(:dir(rtl)) .desv-button {
+					margin: 0.5rem 0 0.6rem 0.6rem;
+				}
 				.desv-progress {
 					position: relative;
 					height: 100%;
@@ -130,6 +133,10 @@ class D2lEnrollmentSummaryView extends EnrollmentsLocalize(EntityMixin(PolymerEl
 					@apply --d2l-body-small-text;
 					letter-spacing: 0.3px;
 					margin-left: 0.2rem;
+				}
+				:host(:dir(rtl)) .desv-continue span {
+					margin-left: 0;
+					margin-right: 0.2rem;
 				}
 				.desv-course-list {
 					margin: 2.5rem 0 0 0;
@@ -253,6 +260,9 @@ class D2lEnrollmentSummaryView extends EnrollmentsLocalize(EntityMixin(PolymerEl
 					height: 2rem;
 					margin: 0.5rem 0.6rem 0.6rem 0;
 					min-width: 6rem;
+				}
+				:host(:dir(rtl)) .desv-button-placeholder {
+					margin: 0.5rem 0 0.6rem 0.6rem;
 				}
 
 				/* desv-title-bar placeholder styles */


### PR DESCRIPTION
# Changes
## Iff RTL is enabled:
1. The layout column padding should be on the inside in the `d2l-enrollment-summary-view-layout`
1. The border on the `d2l-enrollment-summary-view-layout` should be on the left instead of the right
1. The `d2l-enrollment-summary-view` button should have its margin on the opposite side
1. The `d2l-enrollment-summary-view` continue label margin should be on the opposite side
1. The `d2l-enrollment-summary-view-meter` should progress in the correct direction
