### PR TITLE
DE35575 - Hero Banner title will not overflow white box.

### DIFF
--- a/components/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
+++ b/components/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
@@ -88,17 +88,17 @@ class EnrollmentHeroBanner extends EnrollmentsLocalize(EntityMixin(PolymerElemen
 					z-index: -2;
 				}
 				.dehb-info-container {
-					height: 252px;
+					min-height: 252px;
 					position: relative;
 					width: 474px;
 				}
 				.dehb-info-transparent {
 					background: white;
 					border-radius: 8px;
-					height: 100%;
+					height: auto;
 					left: 0;
 					opacity: 0.98;
-					position: absolute;
+					position: relative;
 					top: 0;
 					width: 100%;
 					z-index: -1;
@@ -130,12 +130,12 @@ class EnrollmentHeroBanner extends EnrollmentsLocalize(EntityMixin(PolymerElemen
 					letter-spacing: 0.8px;
 					line-height: 1.4;
 					margin: 0;
+					width: 100%;
 				}
 				.dehb-title {
 					align-items: flex-end;
-					display: inline-block;
-					overflow: hidden; 
-					max-height: 2.8em; /* not a typo meant em */
+					display: flex;
+					overflow: hidden;
 					min-height: 2.26em; /* not a typo meant em */
 				}
 				.dehb-context-menu {
@@ -228,7 +228,8 @@ class EnrollmentHeroBanner extends EnrollmentsLocalize(EntityMixin(PolymerElemen
 						<d2l-organization-image type="wide" href="[[_organizationUrl]]" token=[[token]]></d2l-organization-image>
 					</div>
 					<div class="dehb-info-container">
-						<div class="dehb-info-transparent"><!-- Skeleton for text -->
+						<div class="dehb-info-transparent">
+						<!-- Skeleton for text -->
 						<div class="dehb-base-info-placeholder">
 							<div class="dehb-base-info">
 								<div class="dehb-title">
@@ -247,7 +248,7 @@ class EnrollmentHeroBanner extends EnrollmentsLocalize(EntityMixin(PolymerElemen
 									<div class="dehb-update dehb-update-placeholder"></div>
 								</div>
 							</div>
-						</div>	
+						</div>
 						<div class="dehb-base-info">
 								<div class="dehb-title"><h2>[[_organizationName]]</h2></div>
 								<div class="dehb-context-menu">

--- a/components/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
+++ b/components/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
@@ -2,7 +2,7 @@
 `d2l-enrollment-hero-banner`
 
 Polymer-based web component for a organization name.
- 
+
 @demo demo/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner-demo.html Organization Name
 */
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';

--- a/components/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
+++ b/components/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
@@ -96,10 +96,10 @@ class EnrollmentHeroBanner extends EnrollmentsLocalize(EntityMixin(PolymerElemen
 					background: white;
 					border-radius: 8px;
 					min-height: 252px;
-					height: auto;
+					height: 100%;
 					left: 0;
 					opacity: 0.98;
-					position: relative;
+					position: absolute;
 					top: 0;
 					width: 100%;
 					z-index: -1;
@@ -230,67 +230,66 @@ class EnrollmentHeroBanner extends EnrollmentsLocalize(EntityMixin(PolymerElemen
 						<d2l-organization-image type="wide" href="[[_organizationUrl]]" token=[[token]]></d2l-organization-image>
 					</div>
 					<div class="dehb-info-container">
-						<div class="dehb-info-transparent">
-							<!-- Skeleton for text -->
-							<div class="dehb-base-info-placeholder">
-								<div class="dehb-base-info">
-									<div class="dehb-title">
-										<div class="dehb-text-placeholder dehb-title-placeholder"></div>
-									</div>
-									<div class="dehb-tag-container dehb-tag-placeholder-container">
-										<div class="dehb-text-placeholder dehb-tag-placeholder"></div>
-										<div class="dehb-text-placeholder dehb-tag-placeholder"></div>
-									</div>
-									<div class="dehb-progress-container">
-										<div class="dehb-text-placeholder dehb-progress-placeholder"></div>
-									</div>
-									<div class="dehb-updates-container">
-										<div class="dehb-update dehb-update-placeholder"></div>
-										<div class="dehb-update dehb-update-placeholder"></div>
-										<div class="dehb-update dehb-update-placeholder"></div>
-									</div>
-								</div>
-							</div>
+						<div class="dehb-info-transparent"></div>
+						<!-- Skeleton for text -->
+						<div class="dehb-base-info-placeholder">
 							<div class="dehb-base-info">
-								<div class="dehb-title"><h2>[[_organizationName]]</h2></div>
-								<div class="dehb-context-menu">
-									<template is="dom-if" if="[[_shouldShowDropDown(_canAccessCourseInfo, _canChangeCourseImage)]]">
-										<d2l-dropdown-more text="[[_courseSettingsLabel]]" visible-on-ancestor>
-											<d2l-dropdown-menu>
-												<d2l-menu label="[[_courseSettingsLabel]]">
-													<d2l-menu-item-link hidden$="[[!_canAccessCourseInfo]]" text="[[localize('courseOfferingInformation')]]" href="[[_courseInfoUrl]]">
-													</d2l-menu-item-link>
-													<d2l-menu-item on-d2l-menu-item-select="_launchCourseImageSelector" hidden$="[[!_canChangeCourseImage]]" text="[[localize('changeImage')]]">
-													</d2l-menu-item>
-													<d2l-menu-item on-d2l-menu-item-select="_pinClickHandler" hidden$="[[_shouldHidePinOption(_pinned)]]" text="[[localize('pin')]]">
-													</d2l-menu-item>
-													<d2l-menu-item on-d2l-menu-item-select="_pinClickHandler" hidden$="[[_shouldHideUnpinOption(_pinned)]]" text="[[localize('unpin')]]">
-													</d2l-menu-item>
-											</d2l-dropdown-menu>
-										</d2l-dropdown-more>
-
-										<d2l-button-icon hidden$="[[_shouldHideUnpinOption(_pinned)]]" text="[[_pinButtonLabel]]" icon="d2l-tier1:pin-filled" on-tap="_pinClickHandler" on-keypress="_pinPressHandler">
-										</d2l-button-icon>
-									</template>
+								<div class="dehb-title">
+									<div class="dehb-text-placeholder dehb-title-placeholder"></div>
 								</div>
 								<div class="dehb-tag-container dehb-tag-placeholder-container">
 									<div class="dehb-text-placeholder dehb-tag-placeholder"></div>
 									<div class="dehb-text-placeholder dehb-tag-placeholder"></div>
 								</div>
 								<div class="dehb-progress-container">
-									<d2l-meter-linear class="dehb-progress" value="[[_enrollmentCompletion.value]]" max="[[_enrollmentCompletion.max]]" text="[[_progressLabel]]" text-inline></d2l-meter-linear>
+									<div class="dehb-text-placeholder dehb-progress-placeholder"></div>
 								</div>
 								<div class="dehb-updates-container">
-									<d2l-enrollment-updates
-										href="[[_organizationUrl]]"
-										token=[[token]]
-										show-unattempted-quizzes
-										show-dropbox-unread-feedback
-										show-ungraded-quiz-attempts
-										show-unread-discussion-messages
-										show-unread-dropbox-submissions>
-									</d2l-enrollment-updates>
+									<div class="dehb-update dehb-update-placeholder"></div>
+									<div class="dehb-update dehb-update-placeholder"></div>
+									<div class="dehb-update dehb-update-placeholder"></div>
 								</div>
+							</div>
+						</div>
+						<div class="dehb-base-info">
+							<div class="dehb-title"><h2>[[_organizationName]]</h2></div>
+							<div class="dehb-context-menu">
+								<template is="dom-if" if="[[_shouldShowDropDown(_canAccessCourseInfo, _canChangeCourseImage)]]">
+									<d2l-dropdown-more text="[[_courseSettingsLabel]]" visible-on-ancestor>
+										<d2l-dropdown-menu>
+											<d2l-menu label="[[_courseSettingsLabel]]">
+												<d2l-menu-item-link hidden$="[[!_canAccessCourseInfo]]" text="[[localize('courseOfferingInformation')]]" href="[[_courseInfoUrl]]">
+												</d2l-menu-item-link>
+												<d2l-menu-item on-d2l-menu-item-select="_launchCourseImageSelector" hidden$="[[!_canChangeCourseImage]]" text="[[localize('changeImage')]]">
+												</d2l-menu-item>
+												<d2l-menu-item on-d2l-menu-item-select="_pinClickHandler" hidden$="[[_shouldHidePinOption(_pinned)]]" text="[[localize('pin')]]">
+												</d2l-menu-item>
+												<d2l-menu-item on-d2l-menu-item-select="_pinClickHandler" hidden$="[[_shouldHideUnpinOption(_pinned)]]" text="[[localize('unpin')]]">
+												</d2l-menu-item>
+										</d2l-dropdown-menu>
+									</d2l-dropdown-more>
+
+									<d2l-button-icon hidden$="[[_shouldHideUnpinOption(_pinned)]]" text="[[_pinButtonLabel]]" icon="d2l-tier1:pin-filled" on-tap="_pinClickHandler" on-keypress="_pinPressHandler">
+									</d2l-button-icon>
+								</template>
+							</div>
+							<div class="dehb-tag-container dehb-tag-placeholder-container">
+								<div class="dehb-text-placeholder dehb-tag-placeholder"></div>
+								<div class="dehb-text-placeholder dehb-tag-placeholder"></div>
+							</div>
+							<div class="dehb-progress-container">
+								<d2l-meter-linear class="dehb-progress" value="[[_enrollmentCompletion.value]]" max="[[_enrollmentCompletion.max]]" text="[[_progressLabel]]" text-inline></d2l-meter-linear>
+							</div>
+							<div class="dehb-updates-container">
+								<d2l-enrollment-updates
+									href="[[_organizationUrl]]"
+									token=[[token]]
+									show-unattempted-quizzes
+									show-dropbox-unread-feedback
+									show-ungraded-quiz-attempts
+									show-unread-discussion-messages
+									show-unread-dropbox-submissions>
+								</d2l-enrollment-updates>
 							</div>
 						</div>
 					</div>

--- a/components/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
+++ b/components/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
@@ -130,6 +130,7 @@ class EnrollmentHeroBanner extends EnrollmentsLocalize(EntityMixin(PolymerElemen
 					letter-spacing: 0.8px;
 					line-height: 1.4;
 					margin: 0;
+					word-wrap: break-word;
 					width: 100%;
 				}
 				.dehb-title {

--- a/components/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
+++ b/components/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
@@ -133,7 +133,8 @@ class EnrollmentHeroBanner extends EnrollmentsLocalize(EntityMixin(PolymerElemen
 				}
 				.dehb-title {
 					align-items: flex-end;
-					display: flex;
+					display: inline-block;
+					overflow: hidden; 
 					max-height: 2.8em; /* not a typo meant em */
 					min-height: 2.26em; /* not a typo meant em */
 				}
@@ -227,8 +228,7 @@ class EnrollmentHeroBanner extends EnrollmentsLocalize(EntityMixin(PolymerElemen
 						<d2l-organization-image type="wide" href="[[_organizationUrl]]" token=[[token]]></d2l-organization-image>
 					</div>
 					<div class="dehb-info-container">
-						<div class="dehb-info-transparent"></div>
-						<!-- Skeleton for text -->
+						<div class="dehb-info-transparent"><!-- Skeleton for text -->
 						<div class="dehb-base-info-placeholder">
 							<div class="dehb-base-info">
 								<div class="dehb-title">
@@ -247,46 +247,47 @@ class EnrollmentHeroBanner extends EnrollmentsLocalize(EntityMixin(PolymerElemen
 									<div class="dehb-update dehb-update-placeholder"></div>
 								</div>
 							</div>
-						</div>
+						</div>	
 						<div class="dehb-base-info">
-							<div class="dehb-title"><h2>[[_organizationName]]</h2></div>
-							<div class="dehb-context-menu">
-								<template is="dom-if" if="[[_shouldShowDropDown(_canAccessCourseInfo, _canChangeCourseImage)]]">
-									<d2l-dropdown-more text="[[_courseSettingsLabel]]" visible-on-ancestor>
-										<d2l-dropdown-menu>
-											<d2l-menu label="[[_courseSettingsLabel]]">
-												<d2l-menu-item-link hidden$="[[!_canAccessCourseInfo]]" text="[[localize('courseOfferingInformation')]]" href="[[_courseInfoUrl]]">
-												</d2l-menu-item-link>
-												<d2l-menu-item on-d2l-menu-item-select="_launchCourseImageSelector" hidden$="[[!_canChangeCourseImage]]" text="[[localize('changeImage')]]">
-												</d2l-menu-item>
-												<d2l-menu-item on-d2l-menu-item-select="_pinClickHandler" hidden$="[[_shouldHidePinOption(_pinned)]]" text="[[localize('pin')]]">
-												</d2l-menu-item>
-												<d2l-menu-item on-d2l-menu-item-select="_pinClickHandler" hidden$="[[_shouldHideUnpinOption(_pinned)]]" text="[[localize('unpin')]]">
-												</d2l-menu-item>
-										</d2l-dropdown-menu>
-									</d2l-dropdown-more>
+								<div class="dehb-title"><h2>[[_organizationName]]</h2></div>
+								<div class="dehb-context-menu">
+									<template is="dom-if" if="[[_shouldShowDropDown(_canAccessCourseInfo, _canChangeCourseImage)]]">
+										<d2l-dropdown-more text="[[_courseSettingsLabel]]" visible-on-ancestor>
+											<d2l-dropdown-menu>
+												<d2l-menu label="[[_courseSettingsLabel]]">
+													<d2l-menu-item-link hidden$="[[!_canAccessCourseInfo]]" text="[[localize('courseOfferingInformation')]]" href="[[_courseInfoUrl]]">
+													</d2l-menu-item-link>
+													<d2l-menu-item on-d2l-menu-item-select="_launchCourseImageSelector" hidden$="[[!_canChangeCourseImage]]" text="[[localize('changeImage')]]">
+													</d2l-menu-item>
+													<d2l-menu-item on-d2l-menu-item-select="_pinClickHandler" hidden$="[[_shouldHidePinOption(_pinned)]]" text="[[localize('pin')]]">
+													</d2l-menu-item>
+													<d2l-menu-item on-d2l-menu-item-select="_pinClickHandler" hidden$="[[_shouldHideUnpinOption(_pinned)]]" text="[[localize('unpin')]]">
+													</d2l-menu-item>
+											</d2l-dropdown-menu>
+										</d2l-dropdown-more>
 
-									<d2l-button-icon hidden$="[[_shouldHideUnpinOption(_pinned)]]" text="[[_pinButtonLabel]]" icon="d2l-tier1:pin-filled" on-tap="_pinClickHandler" on-keypress="_pinPressHandler">
-									</d2l-button-icon>
-								</template>
-							</div>
-							<div class="dehb-tag-container dehb-tag-placeholder-container">
-								<div class="dehb-text-placeholder dehb-tag-placeholder"></div>
-								<div class="dehb-text-placeholder dehb-tag-placeholder"></div>
-							</div>
-							<div class="dehb-progress-container">
-								<d2l-meter-linear class="dehb-progress" value="[[_enrollmentCompletion.value]]" max="[[_enrollmentCompletion.max]]" text="[[_progressLabel]]" text-inline></d2l-meter-linear>
-							</div>
-							<div class="dehb-updates-container">
-								<d2l-enrollment-updates
-									href="[[_organizationUrl]]"
-									token=[[token]]
-									show-unattempted-quizzes
-									show-dropbox-unread-feedback
-									show-ungraded-quiz-attempts
-									show-unread-discussion-messages
-									show-unread-dropbox-submissions>
-								</d2l-enrollment-updates>
+										<d2l-button-icon hidden$="[[_shouldHideUnpinOption(_pinned)]]" text="[[_pinButtonLabel]]" icon="d2l-tier1:pin-filled" on-tap="_pinClickHandler" on-keypress="_pinPressHandler">
+										</d2l-button-icon>
+									</template>
+								</div>
+								<div class="dehb-tag-container dehb-tag-placeholder-container">
+									<div class="dehb-text-placeholder dehb-tag-placeholder"></div>
+									<div class="dehb-text-placeholder dehb-tag-placeholder"></div>
+								</div>
+								<div class="dehb-progress-container">
+									<d2l-meter-linear class="dehb-progress" value="[[_enrollmentCompletion.value]]" max="[[_enrollmentCompletion.max]]" text="[[_progressLabel]]" text-inline></d2l-meter-linear>
+								</div>
+								<div class="dehb-updates-container">
+									<d2l-enrollment-updates
+										href="[[_organizationUrl]]"
+										token=[[token]]
+										show-unattempted-quizzes
+										show-dropbox-unread-feedback
+										show-ungraded-quiz-attempts
+										show-unread-discussion-messages
+										show-unread-dropbox-submissions>
+									</d2l-enrollment-updates>
+								</div>
 							</div>
 						</div>
 					</div>

--- a/components/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
+++ b/components/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
@@ -2,7 +2,7 @@
 `d2l-enrollment-hero-banner`
 
 Polymer-based web component for a organization name.
-
+ 
 @demo demo/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner-demo.html Organization Name
 */
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';

--- a/components/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
+++ b/components/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
@@ -137,7 +137,6 @@ class EnrollmentHeroBanner extends EnrollmentsLocalize(EntityMixin(PolymerElemen
 				.dehb-title {
 					align-items: flex-end;
 					display: flex;
-					overflow: hidden;
 					min-height: 2.26em; /* not a typo meant em */
 				}
 				.dehb-context-menu {

--- a/components/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
+++ b/components/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
@@ -95,6 +95,7 @@ class EnrollmentHeroBanner extends EnrollmentsLocalize(EntityMixin(PolymerElemen
 				.dehb-info-transparent {
 					background: white;
 					border-radius: 8px;
+					min-height: 252px;
 					height: auto;
 					left: 0;
 					opacity: 0.98;
@@ -230,27 +231,27 @@ class EnrollmentHeroBanner extends EnrollmentsLocalize(EntityMixin(PolymerElemen
 					</div>
 					<div class="dehb-info-container">
 						<div class="dehb-info-transparent">
-						<!-- Skeleton for text -->
-						<div class="dehb-base-info-placeholder">
-							<div class="dehb-base-info">
-								<div class="dehb-title">
-									<div class="dehb-text-placeholder dehb-title-placeholder"></div>
-								</div>
-								<div class="dehb-tag-container dehb-tag-placeholder-container">
-									<div class="dehb-text-placeholder dehb-tag-placeholder"></div>
-									<div class="dehb-text-placeholder dehb-tag-placeholder"></div>
-								</div>
-								<div class="dehb-progress-container">
-									<div class="dehb-text-placeholder dehb-progress-placeholder"></div>
-								</div>
-								<div class="dehb-updates-container">
-									<div class="dehb-update dehb-update-placeholder"></div>
-									<div class="dehb-update dehb-update-placeholder"></div>
-									<div class="dehb-update dehb-update-placeholder"></div>
+							<!-- Skeleton for text -->
+							<div class="dehb-base-info-placeholder">
+								<div class="dehb-base-info">
+									<div class="dehb-title">
+										<div class="dehb-text-placeholder dehb-title-placeholder"></div>
+									</div>
+									<div class="dehb-tag-container dehb-tag-placeholder-container">
+										<div class="dehb-text-placeholder dehb-tag-placeholder"></div>
+										<div class="dehb-text-placeholder dehb-tag-placeholder"></div>
+									</div>
+									<div class="dehb-progress-container">
+										<div class="dehb-text-placeholder dehb-progress-placeholder"></div>
+									</div>
+									<div class="dehb-updates-container">
+										<div class="dehb-update dehb-update-placeholder"></div>
+										<div class="dehb-update dehb-update-placeholder"></div>
+										<div class="dehb-update dehb-update-placeholder"></div>
+									</div>
 								</div>
 							</div>
-						</div>
-						<div class="dehb-base-info">
+							<div class="dehb-base-info">
 								<div class="dehb-title"><h2>[[_organizationName]]</h2></div>
 								<div class="dehb-context-menu">
 									<template is="dom-if" if="[[_shouldShowDropDown(_canAccessCourseInfo, _canChangeCourseImage)]]">

--- a/demo/data/enrollments/long-name/organizations/2.json
+++ b/demo/data/enrollments/long-name/organizations/2.json
@@ -4,7 +4,7 @@
      "course-offering"
   ],
   "properties":{
-     "name":"Benefits and Equity Compensation Planning",
+     "name":"My idea worked, and I actually was then able to drop the div around the content due to the changes made since I added it. Yaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaay",
      "code":"MTE320",
      "startDate":null,
      "endDate":null,

--- a/demo/data/enrollments/long-name/organizations/2.json
+++ b/demo/data/enrollments/long-name/organizations/2.json
@@ -4,7 +4,7 @@
      "course-offering"
   ],
   "properties":{
-     "name":"My idea worked, and I actually was then able to drop the div around the content due to the changes made since I added it. Yaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaay",
+     "name":"Benefits and Equity Compensation Planning",
      "code":"MTE320",
      "startDate":null,
      "endDate":null,


### PR DESCRIPTION
### Changes
- The css for the hero banner title will now prevent the title from overflowing its container. The container will be the normal height for one or two lines. If the title is greater than two lines, the banner will now wrap the text and expand vertically to fit the title.
- The banner title and content elements are now children of the white box they display in.

Before:
![image](https://user-images.githubusercontent.com/55998273/66342685-03939000-e918-11e9-870c-ac9ffef2315b.png)

After:
![image](https://user-images.githubusercontent.com/55998273/66427422-df9c8100-e9e1-11e9-8de7-2b831eb6e70d.png)

Excessively long words:
![image](https://user-images.githubusercontent.com/55998273/66426851-c21ae780-e9e0-11e9-9de6-0e9ad98febe0.png)





