### PR TITLE
The module name text next to the Continue button is now limited to one line.

### DIFF
--- a/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view.js
+++ b/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view.js
@@ -138,6 +138,9 @@ class D2lEnrollmentSummaryView extends EnrollmentsLocalize(EntityMixin(PolymerEl
 					@apply --d2l-body-small-text;
 					letter-spacing: 0.3px;
 					margin-left: 0.2rem;
+					white-space: nowrap;
+					overflow: hidden;
+					text-overflow: ellipsis;
 				}
 				:host(:dir(rtl)) .desv-continue span {
 					margin-left: 0;


### PR DESCRIPTION
### Changes
If the text extends further than one line, it will no longer wrap and increase the height of the progress bar and continue button. Instead, it will now be truncated by an ellipsis.

### Before
![image](https://user-images.githubusercontent.com/55998273/66603142-7f404780-eb79-11e9-9437-a23a8d80e0a4.png)

### After
![image](https://user-images.githubusercontent.com/55998273/66603126-764f7600-eb79-11e9-88ae-3d5321a651e7.png)
