### PR TITLE
Enrollment Summary's loaded event will now fire even if no modules exist.

### DIFF
--- a/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view.js
+++ b/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view.js
@@ -628,6 +628,11 @@ class D2lEnrollmentSummaryView extends EnrollmentsLocalize(EntityMixin(PolymerEl
 				}, 200);
 			});
 		});
+
+		// Stop-gap solution to delay loaded event firing. If no module is ever loaded, ensures the loaded event still fires after a period of time.
+		setTimeout(() => {
+			this._isCompletionContinueLoaded = true;
+		}, 800);
 	}
 
 	// Couldn't use flat so I stole it from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat


### PR DESCRIPTION
### Changes
Currently, there is no method to get the total module count from the siren-sdk. Consequently, there's no known time at which we can say all modules have loaded.

The existing solution is to wait 200ms after the first module loads to set the loaded flag to true, and fire the event to show the completion button and text. However, if there are no modules to load, this will never fire and the system will remain in a perpetual loading state.

This has been worked around by introducing a backup delay of 800ms that ensures the show completion continue event will still fire in a reasonable amount of time if no modules are loaded,
with 800ms being enough time for an appropriate module to likely have been found and loaded already, while still being fast enough to meet user expectations.

Before:
![image](https://user-images.githubusercontent.com/55998273/67499633-6e023b00-f64f-11e9-9504-98fb82eacf3f.png)

After:
![image](https://user-images.githubusercontent.com/55998273/67499648-722e5880-f64f-11e9-811b-80c4843ab192.png)
