### PR TITLE
Removed skeleton loader placeholders from hero banner

### DIFF
--- a/components/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
+++ b/components/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
@@ -273,8 +273,8 @@ class EnrollmentHeroBanner extends EnrollmentsLocalize(EntityMixin(PolymerElemen
 								</template>
 							</div>
 							<div class="dehb-tag-container dehb-tag-placeholder-container">
-								<div class="dehb-text-placeholder dehb-tag-placeholder"></div>
-								<div class="dehb-text-placeholder dehb-tag-placeholder"></div>
+								<div class="dehb-tag-placeholder"></div>
+								<div class="dehb-tag-placeholder"></div>
 							</div>
 							<div class="dehb-progress-container">
 								<d2l-meter-linear class="dehb-progress" value="[[_enrollmentCompletion.value]]" max="[[_enrollmentCompletion.max]]" text="[[_progressLabel]]" text-inline></d2l-meter-linear>


### PR DESCRIPTION
Skeleton loader placeholders for completion status, duration in the hero banner no longer appear post-load.
The pulsing placeholder elements have been removed but the divs remain to ensure proper spacing via `dehb-tag-placeholder`.
![image](https://user-images.githubusercontent.com/55998273/70351233-7cd73280-1836-11ea-8248-b0201c53bd2e.png)
