### PR TITLE
US112310: Make the My Learning widget responsive

### DIFF
--- a/components/d2l-enrollment-collection-widget/d2l-enrollment-collection-widget.js
+++ b/components/d2l-enrollment-collection-widget/d2l-enrollment-collection-widget.js
@@ -13,6 +13,7 @@ import '../d2l-enrollment-card/d2l-enrollment-card.js';
 import '../d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js';
 import 'd2l-alert/d2l-alert.js';
 import { EnrollmentsLocalize } from '../EnrollmentsLocalize.js';
+import { ResizeObserver } from 'd2l-resize-aware/resize-observer-module.js';
 
 /**
  * @customElement
@@ -22,6 +23,29 @@ class EnrollmentCollectionWidget extends EnrollmentsLocalize(EntityMixin(Polymer
 	constructor() {
 		super();
 		this._setEntityType(EnrollmentCollectionEntity);
+		this._onResize = this._onResize.bind(this);
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+
+		this._resizeObserver = new ResizeObserver(this._onResize);
+		this._resizeObserver.observe(this);
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		if (this._resizeObserver) {
+			this._resizeObserver.unobserve(this);
+		}
+	}
+
+	_onResize(entries) {
+		if (!entries || entries.length === 0) {
+			return;
+		}
+		const entry = entries[0];
+		this._numColumns = this._computeNumColumns(entry.contentRect.width);
 	}
 
 	static get template() {
@@ -32,19 +56,25 @@ class EnrollmentCollectionWidget extends EnrollmentsLocalize(EntityMixin(Polymer
 				}
 				.decw-grid {
 					display: grid;
-					grid-template-columns: [hero-start] 1fr [hero-end];
 					grid-auto-columns: 1fr;
-					grid-gap: 30px 30px;
-				}
-				.decw-grid-4 {
-					grid-template-columns: [hero-start] 1fr 1fr 1fr [hero-end];
+					grid-gap: 15px 15px;
 				}
 				.decw-grid-3 {
+					grid-template-columns: [hero-start] 1fr 1fr 1fr [hero-end];
+				}
+				.decw-grid-3-3 {
 					grid-template-columns: [hero-start] 1fr 1fr [hero-end];
 				}
-				.decw-grid-2 {
-					grid-template-columns: [hero-start] 3fr [hero-end] 1fr;
+				.decw-grid-3-2 {
+					grid-template-columns: [hero-start] 1fr 1fr [hero-end] 1fr;
 				}
+				.decw-grid-2 {
+					grid-template-columns: [hero-start] 1fr 1fr [hero-end];
+				}
+				.decw-grid-1 {
+					grid-template-columns: [hero-start] 1fr [hero-end];
+				}
+
 				.decw-grid-2 d2l-enrollment-card {
 					--course-image-height: 150px;
 				}
@@ -54,10 +84,16 @@ class EnrollmentCollectionWidget extends EnrollmentsLocalize(EntityMixin(Polymer
 				d2l-enrollment-hero-banner {
 					grid-area: 1 / hero-start / 1 / hero-end;
 				}
+				.decw-grid[has-hero] > d2l-enrollment-card:first-of-type {
+					display: none;
+				}
+
 			</style>
 			<template is="dom-if" if="[[_hasEnrollments]]">
-				<div class$="decw-grid decw-grid-[[_countEnrollments]]">
-					<d2l-enrollment-hero-banner href="[[_enrollmentHeroHref]]" token="[[token]]" hide-pinning></d2l-enrollment-hero-banner>
+				<div class$="decw-grid decw-grid-[[_numColumns]] decw-grid-[[_numColumns]]-[[_numEnrollments]]" has-hero$=[[_hasHero]]>
+					<template is="dom-if" if="[[_hasHero]]">
+						<d2l-enrollment-hero-banner href="[[_enrollmentHeroHref]]" token="[[token]]" hide-pinning></d2l-enrollment-hero-banner>
+					</template>
 					<template is="dom-repeat"  items="[[_enrollmentsHref]]">
 						<d2l-enrollment-card href="[[item]]" token="[[token]]"
 								show-unattempted-quizzes
@@ -84,9 +120,17 @@ class EnrollmentCollectionWidget extends EnrollmentsLocalize(EntityMixin(Polymer
 				type: Array,
 				value: () => []
 			},
-			_countEnrollments: {
+			_numColumns: {
 				type: Number,
 				value: 0
+			},
+			_numEnrollments: {
+				type: Number,
+				value: 0
+			},
+			_hasHero: {
+				type: Boolean,
+				computed: '_computeHasHero(_numColumns, _numEnrollments)'
 			},
 			_hasEnrollments: {
 				type: Boolean,
@@ -105,10 +149,24 @@ class EnrollmentCollectionWidget extends EnrollmentsLocalize(EntityMixin(Polymer
 
 	_onEnrollmentCollectionChange(enrollmentCollection) {
 		const enrollments = enrollmentCollection.enrollmentsHref();
-		this._countEnrollments = enrollments.length;
-		this._enrollmentHeroHref = enrollments.shift();
+		this._enrollmentHeroHref = enrollments[0];
 		this._enrollmentsHref = enrollments;
-		this._hasEnrollments = this._countEnrollments !== 0;
+		this._numEnrollments = enrollments.length;
+		this._hasEnrollments = this._numEnrollments !== 0;
+	}
+
+	_computeHasHero(numColumns, numEnrollments) {
+		if (numColumns === 3) {
+			return true;
+		}
+		if (numColumns === 2) {
+			return numEnrollments % 2 !== 0;
+		}
+		return false;
+	}
+
+	_computeNumColumns(containerWidth) {
+		return Math.min(Math.floor(containerWidth / 350), 2) + 1;
 	}
 }
 

--- a/components/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
+++ b/components/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
@@ -80,7 +80,6 @@ class EnrollmentHeroBanner extends EnrollmentsLocalize(EntityMixin(PolymerElemen
 					border-radius: 8px;
 					height: 100%;
 					left: 0;
-					min-width: 510px;
 					overflow:hidden;
 					position: absolute;
 					top: 0;
@@ -90,7 +89,7 @@ class EnrollmentHeroBanner extends EnrollmentsLocalize(EntityMixin(PolymerElemen
 				.dehb-info-container {
 					min-height: 252px;
 					position: relative;
-					width: 474px;
+					max-width: 474px;
 				}
 				.dehb-info-transparent {
 					background: white;


### PR DESCRIPTION
# Changes

- Define the number of columns based on the container width and a column width of 350 px to match My Courses. This was done with `offsetWidth` instead of media queries because different homepage widget layouts result in My Learning having different widths relative to the page size.
- Conditionally show the hero banner based on the number of columns and the number of enrollments.

# Screenshots

## 1 Column
### 1 - 4 Enrollments
![1-4](https://user-images.githubusercontent.com/11379933/72094563-afb49080-32e4-11ea-8e73-6b2a49144102.PNG)

## 2 Column
### 4 Enrollments
![2-4](https://user-images.githubusercontent.com/11379933/72094571-b3e0ae00-32e4-11ea-890d-e16526734bd6.PNG)

### 3 Enrollments
![2-3](https://user-images.githubusercontent.com/11379933/72094580-b6430800-32e4-11ea-9306-ee47dd4f37ea.PNG)

### 2 Enrollments
![2-2](https://user-images.githubusercontent.com/11379933/72094591-bc38e900-32e4-11ea-84b0-daaee7a2404f.PNG)

### 1 Enrollment
![2-1](https://user-images.githubusercontent.com/11379933/72094594-be9b4300-32e4-11ea-8b24-c3fa122b9f39.PNG)

## 3 Column
### 4 Enrollments
![3-4](https://user-images.githubusercontent.com/11379933/72094598-c0fd9d00-32e4-11ea-92e6-d82aba40299b.PNG)

### 3 Enrollments
![3-3](https://user-images.githubusercontent.com/11379933/72094601-c22eca00-32e4-11ea-8551-c2016a3301b1.PNG)

### 2 Enrollments
![3-2](https://user-images.githubusercontent.com/11379933/72094604-c529ba80-32e4-11ea-9c79-a8d61e86d833.PNG)

### 1 Enrollment
![3-1](https://user-images.githubusercontent.com/11379933/72094614-c8bd4180-32e4-11ea-8907-1f1e3416a821.PNG)
