### PR TITLE
Fixed spacing/transparency issue with View All Learning button

### DIFF
--- a/components/d2l-enrollment-collection-widget/d2l-enrollment-collection-widget.js
+++ b/components/d2l-enrollment-collection-widget/d2l-enrollment-collection-widget.js
@@ -115,10 +115,9 @@ class EnrollmentCollectionWidget extends EnrollmentsLocalize(EntityMixin(Polymer
 									hide-pinning>
 							</d2l-enrollment-card>
 						</template>
-						<a href="[[_myLearningHref]]">
+						<a href="[[_myLearningHref]]" class="decw-view-all-learning-button">
 							<d2l-button-subtle
 								aria-hidden="true"
-								class="decw-view-all-learning-button"
 								text="[[localize('viewAllLearning')]]">
 							</d2l-button-subtle>
 						</a>


### PR DESCRIPTION
[DE37466](https://rally1.rallydev.com/#/detail/defect/362140783532?fdp=true)

Spacing issue when using keyboard navigation was due to margins being applied to the button instead of the anchor that wraps the button.

![Screen Shot 2020-01-20 at 4 01 10 PM](https://user-images.githubusercontent.com/2412740/72757999-8a0a6f80-3b9f-11ea-8ff0-a3b1f746e74c.png)

