### PR TITLE
Fixed Edge cards showing up as full width

### DIFF
--- a/components/d2l-enrollment-collection-widget/d2l-enrollment-collection-widget.js
+++ b/components/d2l-enrollment-collection-widget/d2l-enrollment-collection-widget.js
@@ -47,7 +47,8 @@ class EnrollmentCollectionWidget extends EnrollmentsLocalize(EntityMixin(Polymer
 			return;
 		}
 		const entry = entries[0];
-		this._numColumns = this._computeNumColumns(entry.contentRect.width);
+
+		this._numColumns = this._computeNumColumns(parseInt(entry.contentRect.width, 10));
 	}
 
 	static get template() {


### PR DESCRIPTION
[DE37432](https://rally1.rallydev.com/#/detail/defect/361871963468?fdp=true)

Edge cards now display correctly with grids. Issue was due to contentRect.width returning a pixel value (for only Edge, because Edge) instead of a pure number. Simply converting to a number solved the issue.