### PR TITLE
MLW view all anchor untabbable to prevent weird spacing

### DIFF
--- a/components/d2l-enrollment-collection-widget/d2l-enrollment-collection-widget.js
+++ b/components/d2l-enrollment-collection-widget/d2l-enrollment-collection-widget.js
@@ -115,7 +115,7 @@ class EnrollmentCollectionWidget extends EnrollmentsLocalize(EntityMixin(Polymer
 									hide-pinning>
 							</d2l-enrollment-card>
 						</template>
-						<a href="[[_myLearningHref]]" class="decw-view-all-learning-button">
+						<a href="[[_myLearningHref]]" class="decw-view-all-learning-button" tabindex="-1">
 							<d2l-button-subtle
 								aria-hidden="true"
 								text="[[localize('viewAllLearning')]]">


### PR DESCRIPTION
[DE37466](https://rally1.rallydev.com/#/detail/defect/362140783532?fdp=true)

Spacing issue still existed for the My Learning Widget -> View All Learning button, as the problem is that the anchor tag was tabbable. The anchor tag is no longer tabbable, only the button itself is.