### PR TITLE
Disabling link if course is inactive

### DIFF
--- a/components/d2l-enrollment-collection-view/d2l-enrollment-collection-view.js
+++ b/components/d2l-enrollment-collection-view/d2l-enrollment-collection-view.js
@@ -346,7 +346,7 @@ class EnrollmentCollectionView extends LocalizeMixin(EntityMixinLit(LitElement))
 		}
 		const listItems = repeat(items, (item) => item.org.self(), item =>
 			html`
-				<d2l-list-item href="${ifDefined(this._isSearching ? undefined : item.org.organizationHomepageUrl())}">
+				<d2l-list-item href="${ifDefined(this._isSearching || !item.org.isActive() ? undefined : item.org.organizationHomepageUrl())}">
 					<div slot="illustration" class="d2l-enrollment-collection-view-list-item-illustration">
 						${this._renderCourseImageSkeleton()}
 						<d2l-organization-image

--- a/components/d2l-enrollment-collection-view/d2l-enrollment-collection-view.js
+++ b/components/d2l-enrollment-collection-view/d2l-enrollment-collection-view.js
@@ -346,7 +346,7 @@ class EnrollmentCollectionView extends LocalizeMixin(EntityMixinLit(LitElement))
 		}
 		const listItems = repeat(items, (item) => item.org.self(), item =>
 			html`
-				<d2l-list-item href="${ifDefined(this._isSearching || !item.org.isActive() ? undefined : item.org.organizationHomepageUrl())}">
+				<d2l-list-item href="${ifDefined(this._isSearching ? undefined : item.org.organizationHomepageUrl())}">
 					<div slot="illustration" class="d2l-enrollment-collection-view-list-item-illustration">
 						${this._renderCourseImageSkeleton()}
 						<d2l-organization-image

--- a/components/d2l-enrollment-detail-card/d2l-enrollment-detail-card.js
+++ b/components/d2l-enrollment-detail-card/d2l-enrollment-detail-card.js
@@ -105,6 +105,10 @@ class D2lEnrollmentDetailCard extends mixinBehaviors([
 					position: relative;
 					width: 220px;
 				}
+				.dedc-base-container:not([has-link]) .dedc-image {
+					filter: grayscale(1);
+					opacity: 0.5;
+				}
 				.dedc-image-pulse {
 					animation: loadingPulse 1.8s linear infinite;
 					background-color: var(--d2l-color-sylvite);

--- a/components/d2l-enrollment-detail-card/d2l-enrollment-detail-card.js
+++ b/components/d2l-enrollment-detail-card/d2l-enrollment-detail-card.js
@@ -176,9 +176,11 @@ class D2lEnrollmentDetailCard extends mixinBehaviors([
 					background-color: var(--d2l-color-sylvite);
 					border-radius: 4px;
 				}
+				.dedc-base-container[has-link] .dedc-title {
+					color: var(--d2l-color-celestine);
+				}
 				.dedc-title {
 					@apply --d2l-body-standard-text;
-					color: var(--d2l-color-celestine);
 					letter-spacing: 0.4px;
 					line-height: 1;
 					margin: 0 0 0.1rem 0;
@@ -298,7 +300,7 @@ class D2lEnrollmentDetailCard extends mixinBehaviors([
 						</div>
 						<!-- Real text part -->
 						<div class="dedc-base-info">
-							<h3 class="dedc-title"><d2l-organization-name href="[[_organizationUrl]]"  token="[[token]]"></d2l-organization-name></h3>
+							<h3 class="dedc-title"><d2l-organization-name href="[[_organizationUrl]]" token="[[token]]"></d2l-organization-name></h3>
 							<div class="dedc-tag-container" hidden$="[[!_userActivityUsageUrl]]">
 									<span>
 										<d2l-icon icon="d2l-tier1:bullet"></d2l-icon>

--- a/test/d2l-enrollment-card/d2l-enrollment-card.js
+++ b/test/d2l-enrollment-card/d2l-enrollment-card.js
@@ -274,7 +274,7 @@ describe('d2l-enrollment-card', () => {
 			setTimeout(() => {
 				var changeImageMenuItem = component.$$('d2l-menu-item:not([hidden])');
 				expect(changeImageMenuItem).to.not.be.null;
-				expect(changeImageMenuItem.getAttribute('text')).to.equal('Change Image');
+				expect(changeImageMenuItem.text).to.equal('Change Image');
 				done();
 			});
 		});

--- a/test/d2l-enrollment-card/d2l-enrollment-card.js
+++ b/test/d2l-enrollment-card/d2l-enrollment-card.js
@@ -272,9 +272,9 @@ describe('d2l-enrollment-card', () => {
 		it('should have a change-image-button if the set-catalog-image action exists on the organization', done => {
 			component._entity = enrollmentEntity;
 			setTimeout(() => {
-				var changeImageMenuItem = component.$$('d2l-menu-item:not([hidden])').$$('span');
+				var changeImageMenuItem = component.$$('d2l-menu-item:not([hidden])');
 				expect(changeImageMenuItem).to.not.be.null;
-				expect(changeImageMenuItem.innerText).to.equal('Change Image');
+				expect(changeImageMenuItem.getAttribute('text').to.equal('Change Image');
 				done();
 			});
 		});

--- a/test/d2l-enrollment-card/d2l-enrollment-card.js
+++ b/test/d2l-enrollment-card/d2l-enrollment-card.js
@@ -274,7 +274,7 @@ describe('d2l-enrollment-card', () => {
 			setTimeout(() => {
 				var changeImageMenuItem = component.$$('d2l-menu-item:not([hidden])');
 				expect(changeImageMenuItem).to.not.be.null;
-				expect(changeImageMenuItem.getAttribute('text').to.equal('Change Image');
+				expect(changeImageMenuItem.getAttribute('text')).to.equal('Change Image');
 				done();
 			});
 		});


### PR DESCRIPTION
[DE37652](https://rally1.rallydev.com/#/detail/defect/365729624044?fdp=true)

Ensures an activity title does not appear blue (clickable) on the View Learning Path page if it is inactive.

<img width="768" alt="Screen Shot 2020-03-18 at 11 07 23 AM" src="https://user-images.githubusercontent.com/2412740/76975370-d5739c80-6908-11ea-8f40-b1ffd22554d4.png">

**Quality**
Tested with demo pages and local BSI 