### PR TITLE
module name has compact text and has margin auto

### DIFF
--- a/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view.js
+++ b/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view.js
@@ -135,7 +135,8 @@ class D2lEnrollmentSummaryView extends EnrollmentsLocalize(EntityMixin(PolymerEl
 					position: relative;
 				}
 				.desv-continue span {
-					@apply --d2l-body-small-text;
+					@apply --d2l-body-compact-text;
+					margin: auto;
 					letter-spacing: 0.3px;
 					margin-left: 0.2rem;
 					white-space: nowrap;


### PR DESCRIPTION
[DE37672](https://rally1.rallydev.com/#/detail/defect/366100715660?fdp=true)
before:
![image](https://user-images.githubusercontent.com/52468201/78580444-651db400-7800-11ea-8728-d9e262448d3b.png)
after:
![image](https://user-images.githubusercontent.com/52468201/78580477-71097600-7800-11ea-87f3-623e07454e99.png)
**Quality**
Tested with demo pages and local BSI 