### PR TITLE
added an off-screen component for description

### DIFF
--- a/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view.js
+++ b/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view.js
@@ -392,8 +392,8 @@ class D2lEnrollmentSummaryView extends EnrollmentsLocalize(EntityMixin(PolymerEl
 						<div class="desv-placeholder desv-compact-text-placeholder desv-paragraph-placeholder"></div>
 						<div class="desv-placeholder desv-compact-text-placeholder desv-paragraph-placeholder"></div>
 					</div>
-					<h3>[[localize('description')]]</h3>
-					<p>[[_description]]</p>
+					<h3 aria-hidden="true">[[localize('description')]]</h3>
+					<p aria-hidden="true">[[_description]]</p>
 				</div>
 			</d2l-enrollment-summary-view-layout>
 		`;

--- a/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view.js
+++ b/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view.js
@@ -1,6 +1,7 @@
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { EntityMixin } from 'siren-sdk/src/mixin/entity-mixin.js';
 import { EnrollmentEntity } from 'siren-sdk/src/enrollments/EnrollmentEntity.js';
+import '@brightspace-ui/core/components/offscreen/offscreen.js';
 import 'd2l-button/d2l-button-shared-styles.js';
 import 'd2l-link/d2l-link.js';
 import 'd2l-typography/d2l-typography-shared-styles.js';
@@ -339,6 +340,7 @@ class D2lEnrollmentSummaryView extends EnrollmentsLocalize(EntityMixin(PolymerEl
 						<div class="desv-placeholder desv-compact-text-placeholder desv-tags-placeholder"></div>
 					</div>
 					<h1> [[_title]] </h1>
+					<d2l-offscreen>[[_description]]</d2l-offscreen>
 					<d2l-enrollment-summary-view-tag-list list=[[_tags]]></d2l-enrollment-summary-view-tag-list>
 				</div>
 			</div>

--- a/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view.js
+++ b/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view.js
@@ -332,13 +332,13 @@ class D2lEnrollmentSummaryView extends EnrollmentsLocalize(EntityMixin(PolymerEl
 				}
 			</style>
 
-			<div class="desv-header">
+			<div class="desv-header" role="application" aria-labelledby="lp-title" aria-describedby="lp-summary-description">
 				<div class="desv-title-bar" show-text$=[[_showTitle]]>
 					<div class="desv-placeholder-container desv-title-bar-placeholder">
 						<div class="desv-placeholder desv-header-1-placeholder desv-title-placeholder"></div>
 						<div class="desv-placeholder desv-compact-text-placeholder desv-tags-placeholder"></div>
 					</div>
-					<h1> [[_title]] </h1>
+					<h1 id="lp-title"> [[_title]] </h1>
 					<d2l-enrollment-summary-view-tag-list list=[[_tags]]></d2l-enrollment-summary-view-tag-list>
 				</div>
 			</div>
@@ -391,7 +391,7 @@ class D2lEnrollmentSummaryView extends EnrollmentsLocalize(EntityMixin(PolymerEl
 						<div class="desv-placeholder desv-compact-text-placeholder desv-paragraph-placeholder"></div>
 					</div>
 					<h3>[[localize('description')]]</h3>
-					<p>[[_description]]</p>
+					<p id="lp-summary-description">[[_description]]</p>
 				</div>
 			</d2l-enrollment-summary-view-layout>
 		`;

--- a/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view.js
+++ b/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view.js
@@ -332,13 +332,13 @@ class D2lEnrollmentSummaryView extends EnrollmentsLocalize(EntityMixin(PolymerEl
 				}
 			</style>
 
-			<div class="desv-header" role="application" aria-labelledby="lp-title" aria-describedby="lp-summary-description">
+			<div class="desv-header">
 				<div class="desv-title-bar" show-text$=[[_showTitle]]>
 					<div class="desv-placeholder-container desv-title-bar-placeholder">
 						<div class="desv-placeholder desv-header-1-placeholder desv-title-placeholder"></div>
 						<div class="desv-placeholder desv-compact-text-placeholder desv-tags-placeholder"></div>
 					</div>
-					<h1 id="lp-title"> [[_title]] </h1>
+					<h1> [[_title]] </h1>
 					<d2l-enrollment-summary-view-tag-list list=[[_tags]]></d2l-enrollment-summary-view-tag-list>
 				</div>
 			</div>
@@ -391,7 +391,7 @@ class D2lEnrollmentSummaryView extends EnrollmentsLocalize(EntityMixin(PolymerEl
 						<div class="desv-placeholder desv-compact-text-placeholder desv-paragraph-placeholder"></div>
 					</div>
 					<h3>[[localize('description')]]</h3>
-					<p id="lp-summary-description">[[_description]]</p>
+					<p>[[_description]]</p>
 				</div>
 			</d2l-enrollment-summary-view-layout>
 		`;


### PR DESCRIPTION
[DE37664](https://rally1.rallydev.com/#/detail/defect/366057075248?fdp=true)

Basically, I can't seem to find an ideal solution for this. I don't think there is one. We just have to agree on a solution rather than none at all. I'll list the two other solutions below and why it's not a ideal:

1. using `aria-flowto`, limited support in browsers, doesn't work on voiceover, might confuse readers
2. changing html markup to make them seem like the title and description are next to each other. (we tried, its impossible given page design)

**Update**: decided to use offscreen component as it best matches our use-case

Quality
Tested with demo pages and local BSI 
