### PR TITLE
Reverting the d2l-button incorporation

### DIFF
--- a/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view.js
+++ b/components/d2l-enrollment-summary-view/d2l-enrollment-summary-view.js
@@ -3,7 +3,6 @@ import { EntityMixin } from 'siren-sdk/src/mixin/entity-mixin.js';
 import { EnrollmentEntity } from 'siren-sdk/src/enrollments/EnrollmentEntity.js';
 import '@brightspace-ui/core/components/offscreen/offscreen.js';
 import 'd2l-button/d2l-button-shared-styles.js';
-import 'd2l-button/d2l-button.js';
 import 'd2l-link/d2l-link.js';
 import 'd2l-typography/d2l-typography-shared-styles.js';
 import 'd2l-organizations/components/d2l-organization-detail-card/d2l-organization-detail-card.js';
@@ -29,8 +28,48 @@ class D2lEnrollmentSummaryView extends EnrollmentsLocalize(EntityMixin(PolymerEl
 		return html`
 			<!-- Style for the continue button -->
 			<style>
-				d2l-button {
-					margin: 0.6rem 0.6rem 0.6rem 0;
+				.desv-button {
+					font-family: inherit;
+					padding: 0.5rem 1.5rem;
+					@apply --d2l-button-shared;
+					@apply --d2l-label-text;
+					@apply --d2l-button;
+					@apply --d2l-button-clear-focus;
+					text-decoration: none;
+				}
+				/* Firefox includes a hidden border which messes up button dimensions */
+				.desv-button::-moz-focus-inner {
+					border: 0;
+				}
+				.desv-button,
+				.desv-button[disabled]:hover,
+				.desv-button[disabled]:focus {
+					background-color: var(--d2l-color-regolith);
+					border-color: var(--d2l-color-mica);
+					color: var(--d2l-color-ferrite);
+				}
+				.desv-button[disabled] {
+					opacity: 0.5;
+					cursor: default;
+				}
+				.desv-button[primary],
+				.desv-button[primary][disabled]:hover,
+				.desv-button[primary][disabled]:focus {
+					background-color: var(--d2l-color-celestine);
+					border-color: var(--d2l-color-celestine-minus-1);
+					color: #ffffff;
+					@apply --d2l-button-primary;
+				}
+				.desv-button[primary]:hover,
+				.desv-button[primary]:focus {
+					background-color: var(--d2l-color-celestine-minus-1);
+				}
+				.desv-button[primary]:hover {
+					@apply --d2l-button-primary-hover;
+				}
+				.desv-button[primary]:focus {
+					@apply --d2l-button-focus;
+					outline: none; /* needed for Edge, can't be in the mixin */
 				}
 			</style>
 			<style include="d2l-typography-shared-styles">
@@ -323,16 +362,15 @@ class D2lEnrollmentSummaryView extends EnrollmentsLocalize(EntityMixin(PolymerEl
 							<div class="desv-placeholder desv-button-placeholder"></div>
 							<div class="desv-placeholder desv-compact-text-placeholder desv-continue-title-placeholder"></div>
 						</div>
-						<d2l-button
+						<a
+							class="desv-button"
 							primary
 							disabled$="[[!_continueModule.href]]"
 							href$="[[_continueModule.href]]"
-							on-click="_navigateContinueModule"
-							role="link"
 							aria-label$="[[localize('continueToModule', 'module', _continueModule.title)]]">
 								[[localize('continue')]]
-						</d2l-button>
-						<span role="presentation" aria-hidden="true">[[_continueModule.title]]</span>
+						</a>
+						<span>[[_continueModule.title]]</span>
 					</div>
 				</d2l-enrollment-summary-view-layout>
 			</div>
@@ -506,15 +544,6 @@ class D2lEnrollmentSummaryView extends EnrollmentsLocalize(EntityMixin(PolymerEl
 			tags.push(courses.length > 1 ? courses.length + ' Activities' : '1 Activity');
 		}
 		return tags;
-	}
-	_navigateContinueModule() {
-		this._setWindowLocationHref(this._continueModule.href);
-	}
-
-	_setWindowLocationHref(href) {
-		if (href !== '') {
-			window.location.href = href;
-		}
 	}
 	_onCoursesChange(courses) {
 		const coursesLoaded = courses.reduce((map, href) => {


### PR DESCRIPTION
Fixes: [DE38478](https://rally1.rallydev.com/#/detail/defect/379552725536?fdp=true)

Bringing it back to the old link style buttons unfortunately, due to our inability for us to adapt d2l-button for our use-case. This is the same exact code that was there previously, it's just a revert commit.

Quality
Tested with demo pages with VoiceOver on Chrome and local BSI.