### PR TITLE
US115271 - Add focusDropdownOpener to enrollment card

### DIFF
--- a/components/d2l-enrollment-card/d2l-enrollment-card.js
+++ b/components/d2l-enrollment-card/d2l-enrollment-card.js
@@ -488,6 +488,21 @@ class EnrollmentCard extends mixinBehaviors([
 			.catch(this._displaySetImageResult.bind(this, false));
 	}
 
+	focusDropdownOpener(organization) {
+		if (organization && this._getEntityIdentifier(organization) !== this._organizationUrl) {
+			return false;
+		}
+
+		const dropdown = this.shadowRoot.querySelector('d2l-dropdown-more');
+
+		if (dropdown) {
+			dropdown.getOpenerElement().focus();
+			return true;
+		}
+
+		return false;
+	}
+
 	_handlePinnedChange(pinned) {
 		if (pinned) {
 			this.setAttribute('pinned', '');

--- a/test/d2l-enrollment-card/d2l-enrollment-card.js
+++ b/test/d2l-enrollment-card/d2l-enrollment-card.js
@@ -119,6 +119,30 @@ describe('d2l-enrollment-card', () => {
 			expect(component.href).to.equal(undefined);
 		});
 
+		it('if focusDropdownOpener called with different org, return false', (done) => {
+			component._entity = enrollmentEntity;
+
+			requestAnimationFrame(() => {
+				expect(component.focusDropdownOpener({
+					getLinkByRel: function() { return { href: 'different' }; }
+				})).to.be.false;
+				done();
+			});
+		});
+
+		it('if focusDropdownOpener called with same org, try to focus the opener and return true', (done) => {
+			component._entity = enrollmentEntity;
+
+			requestAnimationFrame(() => {
+				const spy = sandbox.spy(component.shadowRoot.querySelector('d2l-dropdown-more'), 'getOpenerElement');
+				expect(component.focusDropdownOpener({
+					getLinkByRel: function() { return { href: 'organizationHref' }; }
+				})).to.be.true;
+				expect(spy).to.have.been.called.calledOnce;
+				done();
+			});
+		});
+
 	});
 
 	describe('Setting the enrollment attribute', () => {


### PR DESCRIPTION
Add `focusDropdownOpener` function for my-courses to use after interacting with the image selector.  Similar to the `refreshImage` function, it first checks that the org you requested matches.  This will be used to fix a bunch of current focus issues in the `my-courses` widget.