### PR TITLE
DE38903 - Fix closed badge

### DIFF
--- a/components/d2l-enrollment-card/d2l-enrollment-card.js
+++ b/components/d2l-enrollment-card/d2l-enrollment-card.js
@@ -640,8 +640,9 @@ class EnrollmentCard extends mixinBehaviors([
 			'date', this.formatDate(processedDate.date, {format: 'MMMM d, yyyy'}),
 			'time', this.formatTime(processedDate.date)
 		);
+
 		this._setOrganizationAccessibleData(org.name(), org.code(), dateText);
-		this._setOrganizationDate(processedDate, org.isActive());
+		this._setOrganizationDate(org.isBeforeStartDate(), org.isAfterEndDate(), org.isActive());
 
 		org.onSemesterChange(function(semester) {
 			this._setSemesterAccessibleData(semester.name());
@@ -681,12 +682,11 @@ class EnrollmentCard extends mixinBehaviors([
 		this._accessibilityDataReset();
 	}
 
-	_setOrganizationDate(date, isActive) {
+	_setOrganizationDate(isBeforeStartDate, isAfterEndDate, isActive) {
 		this._setInactive(!isActive);
-		const afterEndDate = date && date.afterEndDate;
-		this._setClosed(afterEndDate);
-		this._beforeStartDate = date && date.beforeStartDate;
-		if (this._beforeStartDate || (afterEndDate && !this.completed)) {
+		this._setClosed(isAfterEndDate);
+		this._beforeStartDate = isBeforeStartDate;
+		if (this._beforeStartDate || (isAfterEndDate && !this.completed)) {
 			this._orgDateSlot = true;
 		}
 

--- a/components/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
+++ b/components/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
@@ -524,7 +524,7 @@ class EnrollmentHeroBanner extends DateTextAndStatusMixin(EnrollmentsLocalize(En
 			'time', this.formatTime(processedDate.date)
 		);
 		this._setOrganizationAccessibleData(organization.name(), organization.code(), dateText);
-		this._setOrganizationDate(processedDate, organization.isActive());
+		this._setOrganizationDate(organization.isBeforeStartDate(), organization.isAfterEndDate(), organization.isActive());
 
 		organization.onSemesterChange(function(semester) {
 			this._setSemesterAccessibleData(semester.name());
@@ -751,13 +751,12 @@ class EnrollmentHeroBanner extends DateTextAndStatusMixin(EnrollmentsLocalize(En
 		this._accessibilityDataReset();
 	}
 
-	_setOrganizationDate(date, isActive) {
+	_setOrganizationDate(isBeforeStartDate, isAfterEndDate, isActive) {
 		this._setInactive(!isActive);
-		const afterEndDate = date && date.afterEndDate;
-		this._setClosed(afterEndDate);
-		this._beforeStartDate = date && date.beforeStartDate;
+		this._setClosed(isAfterEndDate);
+		this._beforeStartDate = isBeforeStartDate;
 
-		if (this._beforeStartDate || (afterEndDate && !this.completed)) {
+		if (this._beforeStartDate || (isAfterEndDate && !this.completed)) {
 			this._orgDateSlot = true;
 		}
 		this._setBadgeText();

--- a/test/d2l-enrollment-card/d2l-enrollment-card.js
+++ b/test/d2l-enrollment-card/d2l-enrollment-card.js
@@ -18,6 +18,8 @@ describe('d2l-enrollment-card', () => {
 		dateStub,
 		isActiveStub,
 		processedDateStub,
+		isBeforeStartDateStub,
+		isAfterEndDateStub,
 		courseInfoUrlStub,
 		date;
 
@@ -34,6 +36,8 @@ describe('d2l-enrollment-card', () => {
 		organizationHasActionByNameStub = sinon.stub();
 		isActiveStub = sinon.stub();
 		processedDateStub = sinon.stub();
+		isBeforeStartDateStub = sinon.stub();
+		isAfterEndDateStub = sinon.stub();
 		courseInfoUrlStub = sinon.stub();
 		date = new Date(Date.parse('1998-01-01T00:00:00.000Z'));
 
@@ -75,6 +79,8 @@ describe('d2l-enrollment-card', () => {
 			canChangeCourseImage: organizationHasActionByNameStub,
 			isActive: isActiveStub,
 			processedDate: processedDateStub,
+			isBeforeStartDate: isBeforeStartDateStub,
+			isAfterEndDate: isAfterEndDateStub,
 			onSemesterChange: onSemesterChangeStub
 		};
 
@@ -96,6 +102,8 @@ describe('d2l-enrollment-card', () => {
 		organizationHasActionByNameStub.returns(true);
 		isActiveStub.returns(true);
 		processedDateStub.returns(null);
+		isBeforeStartDateStub.returns(null);
+		isAfterEndDateStub.returns(null);
 		courseInfoUrlStub.returns('courseInfoUrl');
 
 		component = fixture('d2l-enrollment-card-fixture');
@@ -416,9 +424,9 @@ describe('d2l-enrollment-card', () => {
 		it('Closed Badge', done => {
 			processedDateStub.returns({
 				type: 'ended',
-				date: date,
-				afterEndDate: true
+				date: date
 			});
+			isAfterEndDateStub.returns(true);
 			component._entity = enrollmentEntity;
 
 			setTimeout(() => {
@@ -442,11 +450,11 @@ describe('d2l-enrollment-card', () => {
 
 		describe('Badge Priority Order', () => {
 			var setClosed = function() {
-				component._setOrganizationDate({
-					type: 'ended',
-					date: date,
-					afterEndDate: true
-				}, true);
+				component._setOrganizationDate(
+					false, // isBeforeStartDate
+					true,  // isAfterEndDate
+					true   // isActive
+				);
 			};
 			var setOverdue = function() {
 				component._setEnrollmentStatus('overdue');
@@ -455,26 +463,26 @@ describe('d2l-enrollment-card', () => {
 				component._setEnrollmentStatus('completed');
 			};
 			var setBeforeStart = function() {
-				component._setOrganizationDate({
-					type: 'ended',
-					date: date,
-					afterEndDate: true
-				}, false);
+				component._setOrganizationDate(
+					true,   // isBeforeStartDate
+					false,  // isAfterEndDate
+					false   // isActive
+				);
 			};
 
 			[
 				{
-					name: 'Completed should be shown when recieved first',
+					name: 'Completed should be shown when received first',
 					methods: [setCompleted, setBeforeStart, setOverdue, setClosed],
 					badge: 'completed'
 				},
 				{
-					name: 'Completed should be shown when recieved last',
+					name: 'Completed should be shown when received last',
 					methods: [setBeforeStart, setOverdue, setClosed, setCompleted],
 					badge: 'completed'
 				},
 				{
-					name: 'Completed should be shown when recieved last',
+					name: 'Completed should be shown when received last',
 					methods: [setOverdue, setCompleted],
 					badge: 'completed'
 				},

--- a/test/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
+++ b/test/d2l-enrollment-hero-banner/d2l-enrollment-hero-banner.js
@@ -23,6 +23,8 @@ describe('d2l-enrollment-hero-banner', () => {
 		dateStub,
 		isActiveStub,
 		processedDateStub,
+		isBeforeStartDateStub,
+		isAfterEndDateStub,
 		date;
 
 	beforeEach(() => {
@@ -44,6 +46,8 @@ describe('d2l-enrollment-hero-banner', () => {
 		onSemesterChangeStub = sinon.stub();
 		isActiveStub = sinon.stub();
 		processedDateStub = sinon.stub();
+		isBeforeStartDateStub = sinon.stub();
+		isAfterEndDateStub = sinon.stub();
 		date = new Date(Date.parse('1998-01-01T00:00:00.000Z'));
 
 		pinStub.returns(true);
@@ -52,6 +56,8 @@ describe('d2l-enrollment-hero-banner', () => {
 		courseInfoUrlStub.returns('courseInfoUrl');
 		isActiveStub.returns(true);
 		processedDateStub.returns(null);
+		isBeforeStartDateStub.returns(null);
+		isAfterEndDateStub.returns(null);
 	});
 
 	afterEach(() => {
@@ -98,6 +104,8 @@ describe('d2l-enrollment-hero-banner', () => {
 				canChangeCourseImage: organizationHasActionByNameStub,
 				isActive: isActiveStub,
 				processedDate: processedDateStub,
+				isBeforeStartDate: isBeforeStartDateStub,
+				isAfterEndDate: isAfterEndDateStub,
 				onSequenceChange: onRootSequenceChangeStub,
 				onSemesterChange: onSemesterChangeStub
 			};
@@ -352,9 +360,9 @@ describe('d2l-enrollment-hero-banner', () => {
 			it('Closed Badge', done => {
 				processedDateStub.returns({
 					type: 'ended',
-					date: date,
-					afterEndDate: true
+					date: date
 				});
+				isAfterEndDateStub.returns(true);
 				component._entity = enrollmentEntity;
 
 				setTimeout(() => {
@@ -381,11 +389,11 @@ describe('d2l-enrollment-hero-banner', () => {
 
 			describe('Badge Priority Order', () => {
 				var setClosed = function() {
-					component._setOrganizationDate({
-						type: 'ended',
-						date: date,
-						afterEndDate: true
-					}, true);
+					component._setOrganizationDate(
+						false, // isBeforeStartDate
+						true,  // isAfterEndDate
+						true   // isActive
+					);
 				};
 				var setOverdue = function() {
 					component._setEnrollmentStatus('overdue');
@@ -394,26 +402,26 @@ describe('d2l-enrollment-hero-banner', () => {
 					component._setEnrollmentStatus('completed');
 				};
 				var setBeforeStart = function() {
-					component._setOrganizationDate({
-						type: 'ended',
-						date: date,
-						afterEndDate: true
-					}, false);
+					component._setOrganizationDate(
+						true,   // isBeforeStartDate
+						false,  // isAfterEndDate
+						false   // isActive
+					);
 				};
 
 				[
 					{
-						name: 'Completed should be shown when recieved first',
+						name: 'Completed should be shown when received first',
 						methods: [setCompleted, setBeforeStart, setOverdue, setClosed],
 						badge: 'completed'
 					},
 					{
-						name: 'Completed should be shown when recieved last',
+						name: 'Completed should be shown when received last',
 						methods: [setBeforeStart, setOverdue, setClosed, setCompleted],
 						badge: 'completed'
 					},
 					{
-						name: 'Completed should be shown when recieved last',
+						name: 'Completed should be shown when received last',
 						methods: [setOverdue, setCompleted],
 						badge: 'completed'
 					},
@@ -544,6 +552,8 @@ describe('d2l-enrollment-hero-banner', () => {
 				canChangeCourseImage: organizationHasActionByNameStub,
 				isActive: isActiveStub,
 				processedDate: processedDateStub,
+				isBeforeStartDate: isBeforeStartDateStub,
+				isAfterEndDate: isAfterEndDateStub,
 				onSequenceChange: onRootSequenceChangeStub,
 				onSemesterChange: onSemesterChangeStub
 			};


### PR DESCRIPTION
Related to BrightspaceHypermediaComponents/siren-sdk#184, I'm migrating usages of the `processedDate` function from `OrganizationEntity` to no longer access `beforeStartDate` and `afterEndDate` directly, and to instead use the new functions.

In this case, the `d2l-enrollment-card` and `d2l-enrollment-hero-banner` were not getting the closed badge applied if `hideCourseEndDate` was true, even though that setting should only affect the date text displayed.  Using the new functions fixes that.  The logic between the two is exactly the same, as are the tests.