### PR TITLE
fix: Localization is broken for enrollment collection in 20.20.8 for Edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
-# enrollments
+# Enrollments
 
 Web components to be used with `enrollments` entities!
 
 `master` contains Polymer 3 entities which can be used with an enrollment entity from the Brightspace Hypermedia APIs.
 
 `hybrid` contains Polymer 1/2 hybrid entities for use with the same entities. With time, this branch will eventually see less usage, as we come to support the newer versions of Polymer, and move things over. For now, though, most elements and changes will be present in this branch.
+
+## Developing
+
+After cloning the repo, run `npm install` to install dependencies.
+
+### Running the demos
+
+`npm start`

--- a/components/d2l-enrollment-collection-view/d2l-enrollment-collection-view.js
+++ b/components/d2l-enrollment-collection-view/d2l-enrollment-collection-view.js
@@ -3,8 +3,7 @@ import { repeat } from 'lit-html/directives/repeat';
 import { ifDefined } from 'lit-html/directives/if-defined';
 import { heading1Styles, bodyStandardStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
-import { getLocalizeResources } from './localization.js';
+import { LocalizeEnrollmentCollectionMixin } from './localization.js';
 import { entityFactory } from 'siren-sdk/src/es6/EntityFactory.js';
 import { EnrollmentCollectionEntity } from 'siren-sdk/src/enrollments/EnrollmentCollectionEntity.js';
 import { classes as organizationClasses } from 'siren-sdk/src/organizations/OrganizationEntity.js';
@@ -22,7 +21,7 @@ import 'd2l-organizations/components/d2l-organization-image/d2l-organization-ima
 import { announce } from '@brightspace-ui/core/helpers/announce.js';
 import { performSirenAction } from 'siren-sdk/src/es6/SirenAction.js';
 
-class EnrollmentCollectionView extends LocalizeMixin(EntityMixinLit(LitElement)) {
+class EnrollmentCollectionView extends LocalizeEnrollmentCollectionMixin(EntityMixinLit(LitElement)) {
 	constructor() {
 		super();
 		this._items = [];
@@ -44,10 +43,6 @@ class EnrollmentCollectionView extends LocalizeMixin(EntityMixinLit(LitElement))
 		this._organizationImageChunk = {};
 
 		this._setEntityType(EnrollmentCollectionEntity);
-	}
-
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
 	}
 
 	set _entity(entity) {

--- a/components/d2l-enrollment-collection-view/localization.js
+++ b/components/d2l-enrollment-collection-view/localization.js
@@ -1,26 +1,65 @@
-import { resolveUrl } from '@polymer/polymer/lib/utils/resolve-url.js';
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 
-export async function getLocalizeResources(langs, importMetaUrl) {
-	const imports = [];
-	let supportedLanguage;
-	for (const language of langs.reverse()) {
-		if (['en', 'ar', 'de', 'es', 'fr', 'ja', 'ko', 'nl', 'pt', 'sv', 'tr', 'zh', 'zh-tw'].includes(language)) {
-			supportedLanguage = language;
-			const filePath = `./lang/${language}.js`;
-			imports.push(import(resolveUrl(filePath, importMetaUrl)));
+export const LocalizeEnrollmentCollectionMixin = superclass => class extends LocalizeMixin(superclass) {
+
+	static async getLocalizeResources(langs) {
+
+		let translations;
+		for await (const lang of langs) {
+			switch (lang) {
+				case 'ar':
+					translations = await import('./lang/ar.js');
+					break;
+				case 'de':
+					translations = await import('./lang/de.js');
+					break;
+				case 'en':
+					translations = await import('./lang/en.js');
+					break;
+				case 'es':
+					translations = await import('./lang/es.js');
+					break;
+				case 'fr':
+					translations = await import('./lang/fr.js');
+					break;
+				case 'ja':
+					translations = await import('./lang/ja.js');
+					break;
+				case 'ko':
+					translations = await import('./lang/ko.js');
+					break;
+				case 'nl':
+					translations = await import('./lang/nl.js');
+					break;
+				case 'pt':
+					translations = await import('./lang/pt.js');
+					break;
+				case 'sv':
+					translations = await import('./lang/sv.js');
+					break;
+				case 'tr':
+					translations = await import('./lang/tr.js');
+					break;
+				case 'zh':
+					translations = await import('./lang/zh.js');
+					break;
+				case 'zh-tw':
+					translations = await import('./lang/zh-tw.js');
+					break;
+			}
+
+			if (translations && translations.default) {
+				return {
+					language: lang,
+					resources: translations.default
+				};
+			}
 		}
-	}
 
-	const translationFiles = await Promise.all(imports);
-	const langterms = {};
-	for (const translationFile of translationFiles) {
-		for (const langterm in translationFile.default) {
-			langterms[langterm] = translationFile.default[langterm];
-		}
+		translations = await import('./lang/en.js');
+		return {
+			language: 'en',
+			resources: translations.default
+		};
 	}
-
-	return {
-		language: supportedLanguage,
-		resources: langterms
-	};
-}
+};

--- a/demo/d2l-enrollment-card/d2l-enrollment-card-demo.html
+++ b/demo/d2l-enrollment-card/d2l-enrollment-card-demo.html
@@ -4,11 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 		<title>d2l-card demo</title>
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-		<script type="module" src="../../../@polymer/polymer/polymer-legacy.js"></script>
-		<script type="module" src="../../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
-		<script type="module" src="../../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
-		<script type="module" src="../../../d2l-typography/d2l-typography.js"></script>
 		<script type="module" src="../../components/d2l-enrollment-card/d2l-enrollment-card.js"></script>
 	<script type="module">
 const $_documentContainer = document.createElement('template');

--- a/demo/d2l-user-activity-usage/d2l-user-activity-usage-demo.html
+++ b/demo/d2l-user-activity-usage/d2l-user-activity-usage-demo.html
@@ -4,12 +4,11 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 		<title>d2l-user-activity-usage</title>
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-		<script type="module" src="../../../@polymer/polymer/polymer-legacy.js"></script>
-		<script type="module" src="../../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
-		<script type="module" src="../../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
-		<script type="module" src="../../../d2l-typography/d2l-typography.js"></script>
-		<script type="module" src="../../components/d2l-user-activity-usage/d2l-user-activity-usage.js"></script>
+		<script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script type="module">
+			import '@brightspace-ui/core/components/demo/demo-page.js';
+			import '../../components/d2l-user-activity-usage/d2l-user-activity-usage.js';
+		</script>
 	<script type="module">
 const $_documentContainer = document.createElement('template');
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://github.com/BrightspaceHypermediaComponents/enrollments",
   "name": "d2l-enrollments",
   "scripts": {
+    "start": "es-dev-server --node-resolve --dedupe --watch --open /demo/",
     "lang:update": "node scripts/updateLangJson.js",
     "lang:build": "gulp build",
     "test": "npm run lint && npm run test:polymer:local",
@@ -73,6 +74,7 @@
     "d2l-sequences": "BrightspaceHypermediaComponents/sequences#semver:^2",
     "d2l-status-indicator": "BrightspaceUI/status-indicator#semver:^3",
     "d2l-tooltip": "BrightspaceUI/tooltip#semver:^3",
+    "es-dev-server": "^1.56.1",
     "intersection-observer": "^0.5.1",
     "lie": "^3.3.0",
     "siren-sdk": "BrightspaceHypermediaComponents/siren-sdk#semver:^1"


### PR DESCRIPTION
closes https://rally1.rallydev.com/#/detail/defect/405077696728?fdp=true

Defect caused by a switch to `rollup` in BSI builds

## Changes
- Changed so that localization imports are explicit
- Installed `es-dev-server` because we should start moving away from `polymer-cli`
  - This will start a dev server and auto-watch files on `npm start`, just like core

## Quality
- Tested that all of the demo pages work. Performed some light maintenance on them
- Tested that My Learning page works in Legacy Edge with local LMS