### PR TITLE
DE40642 - Fix a11y description on the enrollment card if the org changes

### DIFF
--- a/components/d2l-enrollment-card/d2l-enrollment-card.js
+++ b/components/d2l-enrollment-card/d2l-enrollment-card.js
@@ -556,11 +556,7 @@ class EnrollmentCard extends mixinBehaviors([
 	}
 
 	_handleBadgeTextChange(badgeText) {
-		if (!badgeText) {
-			return;
-		}
-
-		this._accessibilityData.badge = this.localize(badgeText);
+		this._accessibilityData.badge = badgeText ? this.localize(badgeText) : null;
 		this._accessibilityDataReset();
 	}
 
@@ -644,6 +640,7 @@ class EnrollmentCard extends mixinBehaviors([
 		this._setOrganizationAccessibleData(org.name(), org.code(), dateText);
 		this._setOrganizationDate(org.isBeforeStartDate(), org.isAfterEndDate(), org.isActive());
 
+		this._setSemesterAccessibleData(); // Clear semester data in case there is none for this org
 		org.onSemesterChange(function(semester) {
 			this._setSemesterAccessibleData(semester.name());
 			this._performanceMark('d2l.enrollment-card.loadSemester');
@@ -663,22 +660,15 @@ class EnrollmentCard extends mixinBehaviors([
 	}
 
 	_setOrganizationAccessibleData(name, code, dateText) {
-		if (name) {
-			this._accessibilityData.organizationName = name;
-		}
-		if (code) {
-			this._accessibilityData.organizationCode = code;
-		}
-		if (dateText) {
-			this._accessibilityData.organizationDate = dateText;
-		}
+		this._accessibilityData.organizationName = name;
+		this._accessibilityData.organizationCode = code;
+		this._accessibilityData.organizationDate = dateText;
+
 		this._accessibilityDataReset();
 	}
 
 	_setSemesterAccessibleData(semesterName) {
-		if (semesterName) {
-			this._accessibilityData.semesterName = semesterName;
-		}
+		this._accessibilityData.semesterName = semesterName;
 		this._accessibilityDataReset();
 	}
 

--- a/test/d2l-enrollment-card/d2l-enrollment-card.js
+++ b/test/d2l-enrollment-card/d2l-enrollment-card.js
@@ -583,6 +583,39 @@ describe('d2l-enrollment-card', () => {
 			});
 		});
 
+		it('Properly clears values from previous org', done => {
+			organizationEntity.onSemesterChange = () => {};
+			component._badgeText = 'Closed';
+			component._accessibilityData = {
+				organizationName: 'Name',
+				organizationCode: 'Code',
+				semesterName: 'Semester',
+				organizationDate: 'Date',
+				badge: 'Closed'
+			};
+
+			setTimeout(() => {
+				const cardText = component.$$('d2l-card').getAttribute('text');
+				expect(cardText).to.contain('Name');
+				expect(cardText).to.contain('Code');
+				expect(cardText).to.contain('Semester');
+				expect(cardText).to.contain('Date');
+				expect(cardText).to.contain('Closed');
+
+				component.onOrganizationChange(organizationEntity);
+
+				setTimeout(() => {
+					const cardText = component.$$('d2l-card').getAttribute('text');
+					expect(cardText).to.contain('Course Name');
+					expect(cardText).to.contain('Course Code');
+					expect(cardText).to.not.contain('Semester');
+					expect(cardText).to.not.contain('Date');
+					expect(cardText).to.not.contain('Closed');
+					done();
+				});
+			});
+		});
+
 	});
 
 	describe('New Enrollment Highlight', () => {


### PR DESCRIPTION
Related to https://github.com/BrightspaceHypermediaComponents/organizations/pull/214, the same issue was happening for the aggregated a11y description higher up in the card.