### PR TITLE
US132256 - Changing the updateCount to a number due to card-footer-link updates

### DIFF
--- a/components/d2l-enrollment-card/d2l-enrollment-updates.js
+++ b/components/d2l-enrollment-card/d2l-enrollment-updates.js
@@ -45,15 +45,15 @@ class EnrollmentUpdates extends OrganizationUpdatesMixin(EntityMixin(PolymerElem
 			</style>
 			<template is="dom-repeat" items="[[_notifications]]">
 				<template is="dom-if" if="[[!item.isDisabled]]">
-					<d2l-card-footer-link id="[[item.key]]" icon="[[item.icon]]" text="[[item.ariaLabel]]" href$="[[item.link]]" secondary-text="[[_toString(item.updateCount)]]">
+					<d2l-card-footer-link id="[[item.key]]" icon="[[item.icon]]" text="[[item.ariaLabel]]" href$="[[item.link]]" secondary-text="[[_toNumber(item.updateCount)]]">
+						<d2l-tooltip slot="tooltip" class="d2l-enrollment-card-updates-tooltip" for="[[item.key]]" position="top" disabled$="[[item.isDisabled]]">
+							<ul>
+								<template is="dom-repeat" items="[[item.toolTip]]">
+									<li>[[item]]</li>
+								</template>
+							</ul>
+						</d2l-tooltip>
 					</d2l-card-footer-link>
-					<d2l-tooltip class="d2l-enrollment-card-updates-tooltip" for="[[item.key]]" position="top" disabled$="[[item.isDisabled]]">
-						<ul>
-							<template is="dom-repeat" items="[[item.toolTip]]">
-								<li>[[item]]</li>
-							</template>
-						</ul>
-					</d2l-tooltip>
 				</template>
 			</template>
 		`;
@@ -114,12 +114,12 @@ class EnrollmentUpdates extends OrganizationUpdatesMixin(EntityMixin(PolymerElem
 		);
 	}
 
-	_toString(a) {
-		if (typeof a !== String) {
-			return a.toString();
+	_toNumber(updateCount) {
+		if (typeof a === Number) {
+			return updateCount;
 		}
 
-		return a;
+		return updateCount === '99+' ? 100 : parseInt(updateCount);
 	}
 }
 

--- a/components/d2l-enrollment-card/d2l-enrollment-updates.js
+++ b/components/d2l-enrollment-card/d2l-enrollment-updates.js
@@ -45,7 +45,7 @@ class EnrollmentUpdates extends OrganizationUpdatesMixin(EntityMixin(PolymerElem
 			</style>
 			<template is="dom-repeat" items="[[_notifications]]">
 				<template is="dom-if" if="[[!item.isDisabled]]">
-					<d2l-card-footer-link id="[[item.key]]" icon="[[item.icon]]" text="[[item.ariaLabel]]" href$="[[item.link]]" secondary-text="[[_toNumber(item.updateCount)]]">
+					<d2l-card-footer-link id="[[item.key]]" icon="[[item.icon]]" text="[[item.ariaLabel]]" href$="[[item.link]]" secondary-count="[[_toNumber(item.updateCount)]]">
 						<d2l-tooltip slot="tooltip" class="d2l-enrollment-card-updates-tooltip" for="[[item.key]]" position="top" disabled$="[[item.isDisabled]]">
 							<ul>
 								<template is="dom-repeat" items="[[item.toolTip]]">


### PR DESCRIPTION
https://github.com/BrightspaceUI/core/pull/1780 makes some breaking changes to the card-footer-link. The secondary-text property has been changed to secondary-count, and only accepts numbers.

Since this is a breaking change, the core repo PR will need to be merged in to get it working again. I'll keep this PR as a draft until we are ready to merge all the changes.